### PR TITLE
Маркиране на завършените стъпки в Stepper

### DIFF
--- a/script.js
+++ b/script.js
@@ -10,14 +10,13 @@ document.addEventListener('DOMContentLoaded', function() {
     function updateStepper() {
         stepperSteps.forEach((step, index) => {
             const stepNumber = index + 1;
+            // изчистваме старите състояния
+            step.classList.remove('active', 'completed');
+
             if (stepNumber === currentStep) {
                 step.classList.add('active');
             } else if (stepNumber < currentStep) {
-                // Ако искате миналите стъпки също да изглеждат "завършени"
-                step.classList.add('active'); 
-            }
-            else {
-                step.classList.remove('active');
+                step.classList.add('completed');
             }
         });
     }

--- a/style.css
+++ b/style.css
@@ -148,6 +148,15 @@ body {
     color: var(--primary-color);
     font-weight: 600;
 }
+.step.completed span {
+    background-color: var(--secondary-color);
+    color: white;
+    border-color: var(--secondary-color);
+}
+.step.completed p {
+    color: var(--secondary-color);
+    font-weight: 600;
+}
 .step-line {
     flex-grow: 1;
     height: 2px;


### PR DESCRIPTION
## Обобщение
- Добавена логика в `updateStepper` за присвояване на клас `.completed` на предишните стъпки
- Нов стил `.step.completed` със зелена маркировка за завършени стъпки

## Тестване
- `npm test` (липсва `package.json`)


------
https://chatgpt.com/codex/tasks/task_e_68922209b6c48326be212dd226be3840