### PR TITLE
Validate image uploads

### DIFF
--- a/index.html
+++ b/index.html
@@ -136,6 +136,8 @@
                         </div>
                     </div>
 
+                    <p class="upload-note">Приемаме само изображения (JPG, PNG) до 5MB.</p>
+
                     <!-- START: Препоръчителна промяна 2 -->
                     <div class="disclaimer-note">
                         <i class="fas fa-info-circle"></i>

--- a/script.js
+++ b/script.js
@@ -61,6 +61,21 @@ document.addEventListener('DOMContentLoaded', function() {
         input.addEventListener('change', function() {
             const file = this.files[0];
             if (file) {
+                // Проверка за тип на файла
+                if (!file.type.startsWith('image/')) {
+                    showError('Моля, качете изображение.');
+                    input.value = '';
+                    return;
+                }
+
+                // Проверка за размер на файла (до 5MB)
+                const maxSize = 5 * 1024 * 1024;
+                if (file.size > maxSize) {
+                    showError('Файлът трябва да е до 5MB.');
+                    input.value = '';
+                    return;
+                }
+
                 const reader = new FileReader();
                 // Изчистване на иконата и текста, за да се види само снимката
                 const icon = preview.querySelector('i');

--- a/style.css
+++ b/style.css
@@ -302,6 +302,13 @@ body {
     margin-top: 0.5rem;
 }
 
+.upload-note {
+    margin-top: 1rem;
+    font-size: 0.9rem;
+    color: #555;
+    text-align: center;
+}
+
 /* Disclaimer Note Style - ДОБАВЕН НОВ БЛОК */
 .disclaimer-note {
     display: flex;


### PR DESCRIPTION
## Summary
- validate uploaded files are images under 5MB
- clarify file size/type limits on upload step

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68924e436ed083268b51f3e453a913ab