### PR TITLE
Обграждане на JSON.parse и логване на AI отговора

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -116,7 +116,17 @@ async function handleAnalysisRequest(request, env) {
         console.log("Стъпка 1: Изпращане на заявка за идентификация на знаци...");
         const identificationApiCaller = AI_PROVIDER === "gemini" ? callGeminiAPI : callOpenAIAPI;
         const keysResponse = await identificationApiCaller(IDENTIFICATION_PROMPT, {}, leftEyeBase64, rightEyeBase64, env, true);
-        const ragKeys = JSON.parse(keysResponse);
+        console.log("Суров отговор от AI:", keysResponse);
+        let ragKeys;
+        try {
+            ragKeys = JSON.parse(keysResponse);
+        } catch (parseError) {
+            console.error("Неуспешно парсване на AI отговора:", parseError);
+            return new Response(JSON.stringify({ error: "Невалиден JSON от AI" }), {
+                status: 500,
+                headers: corsHeaders(request, env),
+            });
+        }
         console.log("Получени RAG ключове за извличане:", ragKeys);
 
         // 3. СТЪПКА 2: ИЗВЛИЧАНЕ НА ДАННИ ОТ KV


### PR DESCRIPTION
## Резюме
- добавен try/catch около JSON.parse за AI отговора
- при грешка връща "Невалиден JSON от AI" и логва суровия резултат

## Тестове
- `node -e "const keysResponse='invalid'; console.log('Суров отговор от AI:', keysResponse); try { JSON.parse(keysResponse); } catch (parseError) { console.error('Неуспешно парсване на AI отговора:', parseError.message); console.error('Невалиден JSON от AI'); }"`


------
https://chatgpt.com/codex/tasks/task_e_68927266c54c8326861a57f8f7d0b765