### PR TITLE
Поддръжка на wildcard при CORS

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -316,15 +316,23 @@ function handleOptions(request, env) {
 
 function corsHeaders(request, env, additionalHeaders = {}) {
     const requestOrigin = request.headers.get("Origin");
-    const allowedOrigins = env.allowed_origin ? env.allowed_origin.split(",").map(o => o.trim()) : [];
-    const origin = requestOrigin && allowedOrigins.includes(requestOrigin) ? requestOrigin : "null";
+    const allowedOrigins = env.allowed_origin
+        ? env.allowed_origin.split(",").map(o => o.trim())
+        : [];
+
+    let origin = "null";
+    if (allowedOrigins.includes("*")) {
+        origin = "*";
+    } else if (requestOrigin && allowedOrigins.includes(requestOrigin)) {
+        origin = requestOrigin;
+    }
 
     return new Headers({
         "Access-Control-Allow-Origin": origin,
         "Access-Control-Allow-Methods": "POST, OPTIONS",
         "Access-Control-Allow-Headers": "Content-Type, Authorization",
-        ...additionalHeaders
+        ...additionalHeaders,
     });
 }
 
-export { fileToBase64, resizeImage };
+export { fileToBase64, resizeImage, corsHeaders };

--- a/worker.test.js
+++ b/worker.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { resizeImage, fileToBase64 } from './worker.js';
+import { resizeImage, fileToBase64, corsHeaders } from './worker.js';
 
 test('resizeImage връща грешка при твърде голям файл', async () => {
   const bigBuffer = Buffer.alloc(6 * 1024 * 1024, 0); // 6MB
@@ -13,4 +13,23 @@ test('fileToBase64 работи за малък файл', async () => {
   const smallFile = new File([smallBuffer], 'small.jpg', { type: 'image/jpeg' });
   const base64 = await fileToBase64(smallFile);
   assert.match(base64, /^[A-Za-z0-9+/=]+$/);
+});
+
+test('corsHeaders поддържа wildcard "*"', () => {
+  const request = new Request('https://api.example', { headers: { Origin: 'https://myapp.example' }});
+  const headers = corsHeaders(request, { allowed_origin: '*' });
+  assert.equal(headers.get('Access-Control-Allow-Origin'), '*');
+});
+
+test('corsHeaders позволява конкретен домейн', () => {
+  const request = new Request('https://api.example', { headers: { Origin: 'https://myapp.example' }});
+  const env = { allowed_origin: 'https://myapp.example,https://other.example' };
+  const headers = corsHeaders(request, env);
+  assert.equal(headers.get('Access-Control-Allow-Origin'), 'https://myapp.example');
+});
+
+test('corsHeaders връща null за неразрешен домейн', () => {
+  const request = new Request('https://api.example', { headers: { Origin: 'https://evil.example' }});
+  const headers = corsHeaders(request, { allowed_origin: 'https://myapp.example' });
+  assert.equal(headers.get('Access-Control-Allow-Origin'), 'null');
 });


### PR DESCRIPTION
## Резюме
- позволено е `allowed_origin="*"` за development
- специфичните домейни се валидират срещу `allowed_origin`
- добавени unit тестове за CORS логиката

## Тестване
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689696a280808326846fe382877fdc62