### PR TITLE
Добавяне на конфигурация за Worker URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,30 @@
 
 Този проект съдържа Cloudflare Worker, който изпълнява многостъпков RAG анализ на ирисови изображения.
 
+## Конфигурация на Worker URL
+
+Фронтендът използва конфигурационен файл [`config.js`](config.js), за да определи адреса на Cloudflare Worker-а.
+
+```js
+// config.js
+export const WORKER_URL =
+  (typeof process !== 'undefined' && process.env && process.env.WORKER_URL) ||
+  (typeof window !== 'undefined' && window.WORKER_URL) ||
+  'https://iris.radilov-k.workers.dev/analyze';
+```
+
+### Задаване през environment променлива
+
+При разработка може да зададете URL-а чрез променлива на средата:
+
+```bash
+export WORKER_URL="https://my-worker.example.com/analyze"
+```
+
+### Ръчно задаване
+
+Алтернативно, редактирайте `config.js` и променете стойността по подразбиране.
+
 ## Подробно логване
 
 По подразбиране логовете са минимални. За да активирате подробното логване:

--- a/config.js
+++ b/config.js
@@ -1,0 +1,4 @@
+export const WORKER_URL =
+  (typeof process !== 'undefined' && process.env && process.env.WORKER_URL) ||
+  (typeof window !== 'undefined' && window.WORKER_URL) ||
+  'https://iris.radilov-k.workers.dev/analyze';

--- a/index.html
+++ b/index.html
@@ -159,7 +159,7 @@
 
     </div>
 
-    <script src="script.js"></script>
+    <script type="module" src="script.js"></script>
 
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,3 +1,5 @@
+import { WORKER_URL } from './config.js';
+
 document.addEventListener('DOMContentLoaded', function() {
     const formSteps = document.querySelectorAll('.form-step');
     const nextBtns = document.querySelectorAll('.next-btn');
@@ -122,8 +124,8 @@ document.addEventListener('DOMContentLoaded', function() {
 
         const formData = new FormData(this);
         
-        // ВАЖНО: Уверете се, че този URL е правилният адрес на вашия Cloudflare Worker
-        const workerUrl = 'https://iris.radilov-k.workers.dev/analyze';
+        // Взимаме URL на Worker-а от конфигурацията
+        const workerUrl = WORKER_URL;
 
         fetch(workerUrl, { 
             method: 'POST', 


### PR DESCRIPTION
## Резюме
- въведен конфигурационен файл `config.js` с възможност за задаване на URL чрез `WORKER_URL`
- `script.js` вече използва адреса от конфигурацията
- документация в `README.md` за конфигуриране на Worker URL

## Тестване
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689699ca65ec8326ae7f71bac186afc4