### PR TITLE
Добавяне на Vary заглавка към CORS логиката

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -327,12 +327,18 @@ function corsHeaders(request, env, additionalHeaders = {}) {
         origin = requestOrigin;
     }
 
-    return new Headers({
+    const headers = {
         "Access-Control-Allow-Origin": origin,
         "Access-Control-Allow-Methods": "POST, OPTIONS",
         "Access-Control-Allow-Headers": "Content-Type, Authorization",
         ...additionalHeaders,
-    });
+    };
+
+    if (origin !== "*") {
+        headers["Vary"] = "Origin";
+    }
+
+    return new Headers(headers);
 }
 
 export { fileToBase64, resizeImage, corsHeaders };

--- a/worker.test.js
+++ b/worker.test.js
@@ -19,6 +19,7 @@ test('corsHeaders поддържа wildcard "*"', () => {
   const request = new Request('https://api.example', { headers: { Origin: 'https://myapp.example' }});
   const headers = corsHeaders(request, { allowed_origin: '*' });
   assert.equal(headers.get('Access-Control-Allow-Origin'), '*');
+  assert.equal(headers.get('Vary'), null);
 });
 
 test('corsHeaders позволява конкретен домейн', () => {
@@ -26,10 +27,12 @@ test('corsHeaders позволява конкретен домейн', () => {
   const env = { allowed_origin: 'https://myapp.example,https://other.example' };
   const headers = corsHeaders(request, env);
   assert.equal(headers.get('Access-Control-Allow-Origin'), 'https://myapp.example');
+  assert.equal(headers.get('Vary'), 'Origin');
 });
 
 test('corsHeaders връща null за неразрешен домейн', () => {
   const request = new Request('https://api.example', { headers: { Origin: 'https://evil.example' }});
   const headers = corsHeaders(request, { allowed_origin: 'https://myapp.example' });
   assert.equal(headers.get('Access-Control-Allow-Origin'), 'null');
+  assert.equal(headers.get('Vary'), 'Origin');
 });


### PR DESCRIPTION
## Обобщение
- Добавена е `Vary: Origin` заглавка в `corsHeaders`, за да се избегне споделяне на кеш между домейни
- Разширени тестове за CORS, които проверяват новата заглавка

## Тестване
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689699bc394c832697fae3f7b86c7000