### PR TITLE
Use responsive sizing for upload preview

### DIFF
--- a/style.css
+++ b/style.css
@@ -285,8 +285,8 @@ body {
     display: none;
 }
 .upload-area .upload-preview {
-    width: 180px;
-    height: 180px;
+    width: clamp(120px, 40vw, 180px);
+    height: clamp(120px, 40vw, 180px);
     border: 2px dashed var(--border-color);
     border-radius: 50%;
     display: flex;


### PR DESCRIPTION
## Summary
- Make upload preview circle responsive with CSS `clamp`

## Testing
- `npm test` *(fails: SyntaxError: The requested module './worker.js' does not provide an export named 'corsHeaders')*

------
https://chatgpt.com/codex/tasks/task_e_68976ac85e5c83269b72025ba0103527