### PR TITLE
feat: upload KV data via script

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,16 @@ AI_PROVIDER = "openai" # или "gemini" (по подразбиране)
 ```js
 const base64 = await fileToBase64(largeFile); // автоматично компресира и връща Base64
 ```
+
+## Синхронизация с Cloudflare KV
+
+В директорията [`KV`](KV/) се съхраняват всички ключове и стойности, които трябва да бъдат налични в пространството **`iris_rag_kv`**. За да ги качите:
+
+```bash
+export CF_ACCOUNT_ID="<your-account-id>"
+export CF_KV_NAMESPACE_ID="<namespace-id>"
+export CF_API_TOKEN="<api-token>"
+npm run upload-kv
+```
+
+Скриптът използва [Cloudflare KV Bulk API](https://developers.cloudflare.com/api/operations/kv-namespace-write-multiple-key-value-pairs) и качва съдържанието на всички файлове в `KV` директорията. При неуспех се извежда описателна грешка.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Този проект съдържа Cloudflare Worker, който изпълнява многостъпков RAG анализ на ирисови изображения.",
   "main": "worker.js",
   "scripts": {
-    "test": "node worker.test.js"
+    "test": "node worker.test.js",
+    "upload-kv": "node upload-kv.js"
   },
   "keywords": [],
   "author": "",

--- a/upload-kv.js
+++ b/upload-kv.js
@@ -1,0 +1,44 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const ACCOUNT_ID = process.env.CF_ACCOUNT_ID;
+const NAMESPACE_ID = process.env.CF_KV_NAMESPACE_ID;
+const API_TOKEN = process.env.CF_API_TOKEN;
+const KV_DIR = path.resolve('KV');
+
+async function bulkUpload(entries) {
+  const url = `https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/storage/kv/namespaces/${NAMESPACE_ID}/bulk`;
+  const res = await fetch(url, {
+    method: 'PUT',
+    headers: {
+      'Authorization': `Bearer ${API_TOKEN}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(entries)
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Неуспешно качване: ${text}`);
+  }
+  console.log('Качването завърши успешно.');
+}
+
+async function main() {
+  if (!ACCOUNT_ID || !NAMESPACE_ID || !API_TOKEN) {
+    console.error('Липсват променливи CF_ACCOUNT_ID, CF_KV_NAMESPACE_ID или CF_API_TOKEN.');
+    process.exit(1);
+  }
+
+  const files = await fs.readdir(KV_DIR);
+  const entries = [];
+  for (const file of files) {
+    const value = await fs.readFile(path.join(KV_DIR, file), 'utf8');
+    entries.push({ key: file, value });
+  }
+  await bulkUpload(entries);
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add `upload-kv.js` to push all files from KV directory to Cloudflare KV namespace
- document KV sync process in README
- expose `upload-kv` npm script

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689781189fe0832690535d60a4f458b6