### PR TITLE
Валидиране на JSON при качване в KV

### DIFF
--- a/upload-kv.js
+++ b/upload-kv.js
@@ -33,6 +33,12 @@ async function main() {
   const entries = [];
   for (const file of files) {
     const value = await fs.readFile(path.join(KV_DIR, file), 'utf8');
+    try {
+      JSON.parse(value);
+    } catch (err) {
+      console.error(`Файлът ${file} съдържа невалиден JSON: ${err.message}`);
+      process.exit(1);
+    }
     entries.push({ key: file, value });
   }
   await bulkUpload(entries);


### PR DESCRIPTION
## Обобщение
- добавен try/catch около JSON.parse за валидиране на файловете преди качване
- при невалиден JSON скриптът прекратява изпълнението с код 1

## Тестване
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897837ed0f88326b4f36d8e13bfc8d2