### PR TITLE
Добавяне на sync-kv и deploy скриптове

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ const base64 = await fileToBase64(largeFile); // автоматично комп
 export CF_ACCOUNT_ID="<your-account-id>"
 export CF_KV_NAMESPACE_ID="<namespace-id>"
 export CF_API_TOKEN="<api-token>"
-npm run upload-kv
+npm run sync-kv
 ```
 
 Скриптът използва [Cloudflare KV Bulk API](https://developers.cloudflare.com/api/operations/kv-namespace-write-multiple-key-value-pairs) и качва съдържанието на всички файлове в `KV` директорията. При неуспех се извежда описателна грешка.
@@ -83,9 +83,16 @@ npm run upload-kv
 Примерна сесия:
 
 ```bash
-npm run upload-kv
+npm run sync-kv
 # Ще бъдат обновени ключове: SIGN_IRIS_RING_CONTRACTION_FURROWS
 # Ще бъдат изтрити ключове: OLD_KEY
+```
+
+За изпълнение на пълен деплой с автоматична синхронизация на KV, използвайте.
+Преди това се уверете, че `CF_ACCOUNT_ID`, `CF_KV_NAMESPACE_ID` и `CF_API_TOKEN` са зададени:
+
+```bash
+npm run deploy
 ```
 
 Така директорията `KV/` служи като източник на истина за съдържанието в Cloudflare KV и позволява синхронизация само с една команда.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "worker.js",
   "scripts": {
     "test": "node worker.test.js",
-    "upload-kv": "node upload-kv.js"
+    "upload-kv": "node upload-kv.js",
+    "sync-kv": "node upload-kv.js",
+    "deploy": "npm run sync-kv && wrangler publish"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Обобщение
- добавен скрипт `sync-kv` за синхронизация на KV
- нов `deploy` скрипт, който синхронизира KV и публикува с wrangler
- README актуализирано с инструкции за `sync-kv` и `deploy`

## Тестове
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a121d765c48326b9ed56186a9bbe6f