### PR TITLE
chore: add KV sync workflow

### DIFF
--- a/.github/workflows/kv-sync.yml
+++ b/.github/workflows/kv-sync.yml
@@ -1,0 +1,26 @@
+name: KV Sync
+
+on:
+  push:
+    paths:
+      - 'KV/**'
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - run: npm install
+      - run: node upload-kv.js
+        env:
+          CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+          CF_KV_NAMESPACE_ID: ${{ secrets.CF_KV_NAMESPACE_ID }}
+      - run: wrangler publish
+        env:
+          CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+          CF_KV_NAMESPACE_ID: ${{ secrets.CF_KV_NAMESPACE_ID }}


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to sync KV changes and publish worker

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a124768d50832698b53efcc980e35d