### PR TITLE
Добавени тестове за admin API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "license": "ISC",
       "dependencies": {
         "dotenv": "^16.6.1"
+      },
+      "devDependencies": {
+        "undici": "^7.13.0"
       }
     },
     "node_modules/dotenv": {
@@ -22,6 +25,16 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.13.0.tgz",
+      "integrity": "sha512-l+zSMssRqrzDcb3fjMkjjLGmuiiK2pMIcV++mJaAc9vhjSGpvM7h43QgP+OAMb1GImHmbPyG2tBXeuyG5iY4gA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -16,5 +16,8 @@
   "type": "module",
   "dependencies": {
     "dotenv": "^16.6.1"
+  },
+  "devDependencies": {
+    "undici": "^7.13.0"
   }
 }

--- a/worker.test.js
+++ b/worker.test.js
@@ -1,6 +1,8 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { resizeImage, fileToBase64, corsHeaders, getAIProvider } from './worker.js';
+import { MockAgent, setGlobalDispatcher, Agent } from 'undici';
+import worker, { resizeImage, fileToBase64, corsHeaders, getAIProvider } from './worker.js';
+import { KV_DATA } from './kv-data.js';
 
 test('resizeImage връща грешка при твърде голям файл', async () => {
   const bigBuffer = Buffer.alloc(6 * 1024 * 1024, 0); // 6MB
@@ -43,4 +45,108 @@ test('getAIProvider избира "gemini" по подразбиране', () => 
 
 test('getAIProvider може да избира OpenAI', () => {
   assert.equal(getAIProvider({ AI_PROVIDER: 'openai' }), 'openai');
+});
+
+test('/admin/keys изисква Basic Auth', async () => {
+  const reqNoAuth = new Request('https://example.com/admin/keys');
+  const resNoAuth = await worker.fetch(reqNoAuth, {});
+  assert.equal(resNoAuth.status, 401);
+
+  const mockAgent = new MockAgent();
+  mockAgent.disableNetConnect();
+  setGlobalDispatcher(mockAgent);
+  const cf = mockAgent.get('https://api.cloudflare.com');
+  cf.intercept({
+    path: '/client/v4/accounts/accid/storage/kv/namespaces/ns/keys',
+    method: 'GET',
+    query: { limit: '1000' }
+  }).reply(200, { result: [], result_info: { list_complete: true } });
+
+  const auth = 'Basic ' + Buffer.from('admin:pass').toString('base64');
+  const env = {
+    ADMIN_USER: 'admin',
+    ADMIN_PASS: 'pass',
+    CF_ACCOUNT_ID: 'accid',
+    CF_KV_NAMESPACE_ID: 'ns',
+    CF_API_TOKEN: 'tok'
+  };
+  const reqAuth = new Request('https://example.com/admin/keys', {
+    headers: { Authorization: auth }
+  });
+  const resAuth = await worker.fetch(reqAuth, env);
+  assert.equal(resAuth.status, 200);
+  assert.deepEqual(await resAuth.json(), { keys: [] });
+
+  mockAgent.assertNoPendingInterceptors();
+  mockAgent.close();
+  setGlobalDispatcher(new Agent());
+});
+
+test('/admin/sync синхронизира данни', async () => {
+  const mockAgent = new MockAgent();
+  mockAgent.disableNetConnect();
+  setGlobalDispatcher(mockAgent);
+  const cf = mockAgent.get('https://api.cloudflare.com');
+  cf.intercept({ path: '/client/v4/user/tokens/verify', method: 'GET' })
+    .reply(200, { success: true });
+  cf.intercept({
+    path: '/client/v4/accounts/accid/storage/kv/namespaces/ns/keys',
+    method: 'GET',
+    query: { limit: '1000' }
+  }).reply(200, { result: [], result_info: { list_complete: true } });
+  cf.intercept({
+    path: '/client/v4/accounts/accid/storage/kv/namespaces/ns/bulk',
+    method: 'PUT'
+  }).reply(200, { success: true });
+
+  const auth = 'Basic ' + Buffer.from('admin:pass').toString('base64');
+  const env = {
+    ADMIN_USER: 'admin',
+    ADMIN_PASS: 'pass',
+    CF_ACCOUNT_ID: 'accid',
+    CF_KV_NAMESPACE_ID: 'ns',
+    CF_API_TOKEN: 'tok'
+  };
+  const req = new Request('https://example.com/admin/sync', {
+    method: 'POST',
+    headers: { Authorization: auth }
+  });
+  const res = await worker.fetch(req, env);
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.deleted.length, 0);
+  assert.equal(body.updated.length, Object.keys(KV_DATA).length);
+
+  mockAgent.assertNoPendingInterceptors();
+  mockAgent.close();
+  setGlobalDispatcher(new Agent());
+});
+
+test('/admin/sync обработва грешки от Cloudflare API', async () => {
+  const mockAgent = new MockAgent();
+  mockAgent.disableNetConnect();
+  setGlobalDispatcher(mockAgent);
+  const cf = mockAgent.get('https://api.cloudflare.com');
+  cf.intercept({ path: '/client/v4/user/tokens/verify', method: 'GET' })
+    .reply(403, 'bad token');
+
+  const auth = 'Basic ' + Buffer.from('admin:pass').toString('base64');
+  const env = {
+    ADMIN_USER: 'admin',
+    ADMIN_PASS: 'pass',
+    CF_ACCOUNT_ID: 'accid',
+    CF_KV_NAMESPACE_ID: 'ns',
+    CF_API_TOKEN: 'tok'
+  };
+  const req = new Request('https://example.com/admin/sync', {
+    method: 'POST',
+    headers: { Authorization: auth }
+  });
+  const res = await worker.fetch(req, env);
+  assert.equal(res.status, 500);
+  assert.equal(await res.text(), 'bad token');
+
+  mockAgent.assertNoPendingInterceptors();
+  mockAgent.close();
+  setGlobalDispatcher(new Agent());
 });


### PR DESCRIPTION
## Обобщение
- Добавени тестове за `/admin/keys` с и без Basic Auth.
- Покрити са позитивни и негативни сценарии за `/admin/sync`.
- Добавена е зависимост `undici` за мокване на Cloudflare API.

## Тестване
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1372243588326bf828a404386b221