### PR TITLE
Премахване на /admin/sync и корекция на base64

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -13,9 +13,6 @@
 <body>
   <div class="container admin-container">
     <h1>Администрация</h1>
-    <div class="admin-actions">
-      <button id="sync-btn" class="cta-button">Синхронизирай KV</button>
-    </div>
     <h2>Ключове в KV</h2>
     <ul id="kv-list"></ul>
     <div id="editor" class="admin-editor" style="display:none;">

--- a/admin.js
+++ b/admin.js
@@ -1,5 +1,4 @@
 document.addEventListener('DOMContentLoaded', () => {
-  const syncBtn = document.getElementById('sync-btn');
   const listEl = document.getElementById('kv-list');
   const editor = document.getElementById('editor');
   const keyInput = document.getElementById('kv-key');
@@ -72,20 +71,6 @@ document.addEventListener('DOMContentLoaded', () => {
       await loadKeys();
     } catch (err) {
       alert('Грешка: ' + err.message);
-    }
-  });
-
-  syncBtn.addEventListener('click', async () => {
-    syncBtn.disabled = true;
-    try {
-      const res = await fetch('/admin/sync', { method: 'POST', credentials: 'include' });
-      if (!res.ok) throw new Error(await res.text());
-      alert('KV синхронизацията завърши успешно');
-      await loadKeys();
-    } catch (err) {
-      alert('Грешка: ' + err.message);
-    } finally {
-      syncBtn.disabled = false;
     }
   });
 

--- a/worker.js
+++ b/worker.js
@@ -1,4 +1,3 @@
-import { KV_DATA } from './kv-data.js';
 
 // Инлайн на ROLE_PROMPT, за да няма външни зависимости при деплой
 const ROLE_PROMPT = `
@@ -37,7 +36,9 @@ function debugLog(env = {}, ...args) {
 
 function toBase64(str) {
     if (typeof btoa !== 'undefined') return btoa(str);
-    return Buffer.from(str, 'utf8').toString('base64');
+    const Buf = globalThis["Buffer"];
+    if (Buf) return Buf.from(str, 'utf8').toString('base64');
+    throw new Error('Base64 не е наличен');
 }
 
 // --- ПРОМПТОВЕ ---
@@ -109,9 +110,6 @@ async function handleAdmin(request, env) {
     }
 
     const url = new URL(request.url);
-    if (url.pathname === '/admin/sync' && request.method === 'POST') {
-        return adminSync(env);
-    }
     if (url.pathname === '/admin/keys' && request.method === 'GET') {
         return adminKeys(env);
     }
@@ -134,58 +132,6 @@ function verifyBasicAuth(request, env) {
     const pass = env.ADMIN_PASS || 'admin';
     const expected = 'Basic ' + toBase64(`${user}:${pass}`);
     return request.headers.get('Authorization') === expected;
-}
-
-async function adminSync(env) {
-    const { CF_ACCOUNT_ID, CF_KV_NAMESPACE_ID, CF_API_TOKEN } = env;
-    if (!CF_ACCOUNT_ID || !CF_KV_NAMESPACE_ID || !CF_API_TOKEN) {
-        return new Response('Липсват CF_* променливи.', { status: 500 });
-    }
-
-    const verify = await fetch('https://api.cloudflare.com/client/v4/user/tokens/verify', {
-        headers: { 'Authorization': `Bearer ${CF_API_TOKEN}` }
-    });
-    if (!verify.ok) {
-        const text = await verify.text();
-        return new Response(text, { status: 500 });
-    }
-
-    const files = Object.keys(KV_DATA);
-    const existingKeys = await fetchExistingKeysCF(env);
-    const toDelete = existingKeys.filter(k => !files.includes(k));
-
-    const entries = [];
-    for (const file of files) {
-        const value = KV_DATA[file];
-        try {
-            JSON.parse(value);
-        } catch (err) {
-            return new Response(`Невалиден JSON в ${file}`, { status: 500 });
-        }
-        entries.push({ key: file, value });
-    }
-    for (const key of toDelete) {
-        entries.push({ key, delete: true });
-    }
-
-    const url = `https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/storage/kv/namespaces/${CF_KV_NAMESPACE_ID}/bulk`;
-    const res = await fetch(url, {
-        method: 'PUT',
-        headers: {
-            'Authorization': `Bearer ${CF_API_TOKEN}`,
-            'Content-Type': 'application/json'
-        },
-        body: JSON.stringify(entries)
-    });
-
-    if (!res.ok) {
-        const text = await res.text();
-        return new Response(text, { status: 500 });
-    }
-
-    return new Response(JSON.stringify({ updated: files, deleted: toDelete }), {
-        headers: { 'Content-Type': 'application/json' }
-    });
 }
 
 async function adminKeys(env) {

--- a/worker.test.js
+++ b/worker.test.js
@@ -2,7 +2,6 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { MockAgent, setGlobalDispatcher, Agent } from 'undici';
 import worker, { resizeImage, fileToBase64, corsHeaders, getAIProvider } from './worker.js';
-import { KV_DATA } from './kv-data.js';
 
 test('resizeImage връща грешка при твърде голям файл', async () => {
   const bigBuffer = Buffer.alloc(6 * 1024 * 1024, 0); // 6MB
@@ -82,71 +81,3 @@ test('/admin/keys изисква Basic Auth', async () => {
   setGlobalDispatcher(new Agent());
 });
 
-test('/admin/sync синхронизира данни', async () => {
-  const mockAgent = new MockAgent();
-  mockAgent.disableNetConnect();
-  setGlobalDispatcher(mockAgent);
-  const cf = mockAgent.get('https://api.cloudflare.com');
-  cf.intercept({ path: '/client/v4/user/tokens/verify', method: 'GET' })
-    .reply(200, { success: true });
-  cf.intercept({
-    path: '/client/v4/accounts/accid/storage/kv/namespaces/ns/keys',
-    method: 'GET',
-    query: { limit: '1000' }
-  }).reply(200, { result: [], result_info: { list_complete: true } });
-  cf.intercept({
-    path: '/client/v4/accounts/accid/storage/kv/namespaces/ns/bulk',
-    method: 'PUT'
-  }).reply(200, { success: true });
-
-  const auth = 'Basic ' + Buffer.from('admin:pass').toString('base64');
-  const env = {
-    ADMIN_USER: 'admin',
-    ADMIN_PASS: 'pass',
-    CF_ACCOUNT_ID: 'accid',
-    CF_KV_NAMESPACE_ID: 'ns',
-    CF_API_TOKEN: 'tok'
-  };
-  const req = new Request('https://example.com/admin/sync', {
-    method: 'POST',
-    headers: { Authorization: auth }
-  });
-  const res = await worker.fetch(req, env);
-  assert.equal(res.status, 200);
-  const body = await res.json();
-  assert.equal(body.deleted.length, 0);
-  assert.equal(body.updated.length, Object.keys(KV_DATA).length);
-
-  mockAgent.assertNoPendingInterceptors();
-  mockAgent.close();
-  setGlobalDispatcher(new Agent());
-});
-
-test('/admin/sync обработва грешки от Cloudflare API', async () => {
-  const mockAgent = new MockAgent();
-  mockAgent.disableNetConnect();
-  setGlobalDispatcher(mockAgent);
-  const cf = mockAgent.get('https://api.cloudflare.com');
-  cf.intercept({ path: '/client/v4/user/tokens/verify', method: 'GET' })
-    .reply(403, 'bad token');
-
-  const auth = 'Basic ' + Buffer.from('admin:pass').toString('base64');
-  const env = {
-    ADMIN_USER: 'admin',
-    ADMIN_PASS: 'pass',
-    CF_ACCOUNT_ID: 'accid',
-    CF_KV_NAMESPACE_ID: 'ns',
-    CF_API_TOKEN: 'tok'
-  };
-  const req = new Request('https://example.com/admin/sync', {
-    method: 'POST',
-    headers: { Authorization: auth }
-  });
-  const res = await worker.fetch(req, env);
-  assert.equal(res.status, 500);
-  assert.equal(await res.text(), 'bad token');
-
-  mockAgent.assertNoPendingInterceptors();
-  mockAgent.close();
-  setGlobalDispatcher(new Agent());
-});


### PR DESCRIPTION
## Обобщение
- премахнат е `/admin/sync` и зависимостта от `kv-data.js`
- базовият `toBase64` вече използва глобален `Buffer` при нужда
- почистени са админ интерфейсът и тестовете

## Тестване
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a14171eb808326a3291a3440e0c3c4