### PR TITLE
Премахване на KV_DATA и JSON синхронизация в /admin/sync

### DIFF
--- a/worker.test.js
+++ b/worker.test.js
@@ -109,7 +109,8 @@ test('/admin/sync синхронизира данни', async () => {
   };
   const req = new Request('https://example.com/admin/sync', {
     method: 'POST',
-    headers: { Authorization: auth }
+    headers: { Authorization: auth, 'Content-Type': 'application/json' },
+    body: JSON.stringify(KV_DATA)
   });
   const res = await worker.fetch(req, env);
   assert.equal(res.status, 200);
@@ -140,7 +141,8 @@ test('/admin/sync обработва грешки от Cloudflare API', async ()
   };
   const req = new Request('https://example.com/admin/sync', {
     method: 'POST',
-    headers: { Authorization: auth }
+    headers: { Authorization: auth, 'Content-Type': 'application/json' },
+    body: '{}'
   });
   const res = await worker.fetch(req, env);
   assert.equal(res.status, 500);


### PR DESCRIPTION
## Резюме
- Работникът вече не използва локален `KV_DATA`, а `/admin/sync` чете KV двойки от JSON тяло и ги синхронизира с Cloudflare KV.
- `toBase64` разчита само на `btoa`, премахвайки зависимостта от `Buffer`.
- Тестовете изпращат JSON към `/admin/sync` и валидират обновената логика.

## Тестване
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a13e4e808c8326b0f01dd71af714ad