### PR TITLE
Опростен админ интерфейс със синхронизация на KV

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -15,20 +15,11 @@
   <div class="container admin-container">
     <h1>Администрация</h1>
     <div class="admin-actions">
-      <button id="new-key-btn" class="cta-button">Нов ключ</button>
       <button id="sync-btn" class="cta-button">Синхронизирай KV</button>
     </div>
     <h2>Ключове в KV</h2>
     <ul id="kv-list"></ul>
-    <div id="editor" class="admin-editor" style="display:none;">
-      <h3>Редакция на ключ</h3>
-      <input id="kv-key" type="text">
-      <textarea id="kv-value"></textarea>
-      <div class="button-group">
-        <button id="save-btn" class="cta-button">Запази</button>
-        <button id="delete-btn" class="cta-button" style="background: #dc3545;">Изтрий</button>
-      </div>
-    </div>
+    <pre id="kv-viewer" class="admin-viewer" style="display:none;"></pre>
     <div id="message-box"></div>
   </div>
   <script type="module" src="admin.js"></script>

--- a/admin.js
+++ b/admin.js
@@ -3,12 +3,7 @@ import { KV_DATA } from './kv-data.js';
 document.addEventListener('DOMContentLoaded', () => {
   const syncBtn = document.getElementById('sync-btn');
   const listEl = document.getElementById('kv-list');
-  const editor = document.getElementById('editor');
-  const keyInput = document.getElementById('kv-key');
-  const valueTextarea = document.getElementById('kv-value');
-  const saveBtn = document.getElementById('save-btn');
-  const deleteBtn = document.getElementById('delete-btn');
-  const newKeyBtn = document.getElementById('new-key-btn');
+  const viewer = document.getElementById('kv-viewer');
   const loadingEl = document.getElementById('loading');
   const messageBox = document.getElementById('message-box');
 
@@ -21,7 +16,6 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function showMessage(msg, type = 'error') {
-    if (!messageBox) return;
     messageBox.textContent = msg;
     messageBox.className = type === 'error' ? 'error-box' : 'success-box';
   }
@@ -36,7 +30,7 @@ document.addEventListener('DOMContentLoaded', () => {
       data.keys.forEach(k => {
         const li = document.createElement('li');
         li.textContent = k;
-        li.addEventListener('click', () => openEditor(k));
+        li.addEventListener('click', () => showKey(k));
         listEl.appendChild(li);
       });
     } catch (err) {
@@ -46,70 +40,22 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
-  async function openEditor(key) {
+  async function showKey(key) {
     showLoading();
     try {
       const res = await fetch(`/admin/get?key=${encodeURIComponent(key)}`, { credentials: 'include' });
       if (!res.ok) throw new Error(await res.text());
       const data = await res.json();
-      keyInput.value = data.key;
       let val = data.value || '';
       try { val = JSON.stringify(JSON.parse(val), null, 2); } catch {}
-      valueTextarea.value = val;
-      editor.style.display = 'block';
+      viewer.textContent = val;
+      viewer.style.display = 'block';
     } catch (err) {
       showMessage('Грешка: ' + err.message);
     } finally {
       hideLoading();
     }
   }
-
-  saveBtn.addEventListener('click', async () => {
-    showLoading();
-    try {
-      const res = await fetch('/admin/put', {
-        method: 'PUT',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ key: keyInput.value, value: valueTextarea.value })
-      });
-      if (!res.ok) throw new Error(await res.text());
-      showMessage('Записът е обновен успешно', 'success');
-      await loadKeys();
-    } catch (err) {
-      showMessage('Грешка: ' + err.message);
-    } finally {
-      hideLoading();
-    }
-  });
-
-  deleteBtn.addEventListener('click', async () => {
-    if (!confirm('Сигурни ли сте, че искате да изтриете този ключ?')) return;
-    showLoading();
-    try {
-      const res = await fetch(`/admin/delete?key=${encodeURIComponent(keyInput.value)}`, {
-        method: 'DELETE',
-        credentials: 'include'
-      });
-      if (!res.ok) throw new Error(await res.text());
-      showMessage('Ключът е изтрит', 'success');
-      editor.style.display = 'none';
-      keyInput.value = '';
-      valueTextarea.value = '';
-      await loadKeys();
-    } catch (err) {
-      showMessage('Грешка: ' + err.message);
-    } finally {
-      hideLoading();
-    }
-  });
-
-  newKeyBtn.addEventListener('click', () => {
-    keyInput.value = '';
-    valueTextarea.value = '';
-    editor.style.display = 'block';
-    keyInput.focus();
-  });
 
   syncBtn.addEventListener('click', async () => {
     syncBtn.disabled = true;
@@ -121,10 +67,11 @@ document.addEventListener('DOMContentLoaded', () => {
         body: JSON.stringify(KV_DATA)
       });
       if (!res.ok) throw new Error(await res.text());
-      alert('KV синхронизацията завърши успешно');
+      const result = await res.json();
+      showMessage(`Обновени: ${result.updated.length}, изтрити: ${result.deleted.length}`, 'success');
       await loadKeys();
     } catch (err) {
-      alert('Грешка: ' + err.message);
+      showMessage('Грешка: ' + err.message);
     } finally {
       syncBtn.disabled = false;
     }
@@ -132,3 +79,4 @@ document.addEventListener('DOMContentLoaded', () => {
 
   loadKeys();
 });
+

--- a/style.css
+++ b/style.css
@@ -52,30 +52,15 @@ body {
     cursor: pointer;
 }
 
-.admin-editor {
+.admin-viewer {
     margin-top: 1rem;
     background: var(--card-bg);
     padding: 1rem;
     border: 1px solid var(--border-color);
     border-radius: 8px;
     box-shadow: 0 2px 4px rgba(0,0,0,0.05);
-}
-
-.admin-editor input,
-.admin-editor textarea {
-    width: 100%;
-    padding: 0.5rem;
-    margin-bottom: 0.5rem;
-}
-
-.admin-editor textarea {
-    height: 200px;
+    white-space: pre-wrap;
     font-family: monospace;
-}
-
-.admin-editor .button-group {
-    display: flex;
-    gap: 0.5rem;
 }
 
 .loading {


### PR DESCRIPTION
## Резюме
- премахнати действия за създаване и редакция на ключове в админ страницата
- добавен read-only viewer за стойностите и бутон за синхронизация спрямо KV данните в репото
- обновени стилове за новия viewer

## Тестване
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a20ad3406c83268609ffc23893bc40