### PR TITLE
Добавяне на diff и потвърждение за KV синхронизация

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -22,6 +22,27 @@
     <pre id="kv-viewer" class="admin-viewer" style="display:none;"></pre>
     <div id="message-box"></div>
   </div>
+  <div id="diff-modal" class="modal">
+    <div class="modal-content">
+      <h3>Разлики в KV</h3>
+      <div class="diff-section">
+        <strong>Нови ключове</strong>
+        <ul id="diff-added"></ul>
+      </div>
+      <div class="diff-section">
+        <strong>Променени ключове</strong>
+        <ul id="diff-changed"></ul>
+      </div>
+      <div class="diff-section">
+        <strong>Изтрити ключове</strong>
+        <ul id="diff-deleted"></ul>
+      </div>
+      <div class="modal-actions">
+        <button id="confirm-sync" class="cta-button">Потвърди</button>
+        <button id="cancel-sync" class="cta-button" style="background:#ccc;">Отказ</button>
+      </div>
+    </div>
+  </div>
   <script type="module" src="admin.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -78,6 +78,33 @@ body {
     color: var(--primary-color);
 }
 
+.modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.5);
+    display: none;
+    justify-content: center;
+    align-items: center;
+    z-index: 1001;
+}
+
+.modal-content {
+    background: var(--card-bg);
+    padding: 1.5rem;
+    border-radius: 8px;
+    max-width: 500px;
+    width: 90%;
+}
+
+.diff-section { margin-bottom: 1rem; }
+.diff-section ul { list-style: disc; margin-left: 1.5rem; }
+
+.modal-actions { text-align: right; margin-top: 1rem; }
+.modal-actions button { margin-left: 0.5rem; }
+
 /* =============================================== */
 /* === ОСНОВНА СТРАНИЦА (HERO & FORM) === */
 /* =============================================== */


### PR DESCRIPTION
## Обобщение
- Добавен е бекенд маршрут `/admin/diff`, който изчислява нови, променени и изтрити KV ключове без да ги синхронизира.
- Разширен е админ интерфейсът с модален прозорец, визуализиращ разликите и изискващ потвърждение преди `POST /admin/sync`.
- Добавен е стил за модалния прозорец и помощни функции за показване на разликите.

## Тестване
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a20f0d5eb883269a536b08c23a6f40