### PR TITLE
Подобряване на CORS за wildcard и креденшъли

### DIFF
--- a/worker.test.js
+++ b/worker.test.js
@@ -19,8 +19,16 @@ test('fileToBase64 работи за малък файл', async () => {
 test('corsHeaders поддържа wildcard "*"', () => {
   const request = new Request('https://api.example', { headers: { Origin: 'https://myapp.example' }});
   const headers = corsHeaders(request, { allowed_origin: '*' });
-  assert.equal(headers.get('Access-Control-Allow-Origin'), '*');
-  assert.equal(headers.get('Vary'), null);
+  assert.equal(headers.get('Access-Control-Allow-Origin'), 'https://myapp.example');
+  assert.equal(headers.get('Vary'), 'Origin');
+});
+
+test('corsHeaders добавя Allow-Credentials при Authorization', () => {
+  const request = new Request('https://api.example', {
+    headers: { Origin: 'https://myapp.example', Authorization: 'Basic abc' }
+  });
+  const headers = corsHeaders(request, { allowed_origin: '*' });
+  assert.equal(headers.get('Access-Control-Allow-Credentials'), 'true');
 });
 
 test('corsHeaders позволява конкретен домейн', () => {


### PR DESCRIPTION
## Обобщение
- Огледално връщане на `Origin`, когато конфигурацията допуска `*`, за да работят заявките с креденшъли
- Добавяне на `Access-Control-Allow-Credentials: true` при заявки с `Authorization`/`Cookie`
- Обновени тестове за новото поведение на `corsHeaders`

## Тестване
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a22ec44a5883269c16b7747f212b51