### PR TITLE
Avoid browser storage in Worker

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -359,13 +359,24 @@ async function handleAnalysisRequest(request, env) {
             throw e;
         }
 
-        if (typeof localStorage !== 'undefined') {
-            try {
-                localStorage.setItem('lastAnalysis', JSON.stringify(parsedAnalysis));
-                localStorage.setItem('holistic_analysis', parsedAnalysis.holistic_analysis);
-            } catch (e) {
-                log('Неуспешен запис в localStorage:', e.message);
+        // Cloudflare Worker няма достъп до браузърно API като localStorage,
+        // затова кешираме анализа в KV или в edge cache.
+        try {
+            if (env.HOLISTIC_CACHE) {
+                await env.HOLISTIC_CACHE.put('lastAnalysis', JSON.stringify(parsedAnalysis));
+                await env.HOLISTIC_CACHE.put('holistic_analysis', parsedAnalysis.holistic_analysis);
+            } else {
+                await caches.default.put(
+                    new Request('https://analysis.local/lastAnalysis'),
+                    new Response(JSON.stringify(parsedAnalysis))
+                );
+                await caches.default.put(
+                    new Request('https://analysis.local/holistic'),
+                    new Response(parsedAnalysis.holistic_analysis)
+                );
             }
+        } catch (e) {
+            log('Неуспешен запис в кеша:', e.message);
         }
 
         return new Response(JSON.stringify(parsedAnalysis), { headers: corsHeaders(request, env, {'Content-Type': 'application/json; charset=utf-8'}) });


### PR DESCRIPTION
## Summary
- remove localStorage usage in `worker.js`
- cache generated analysis using KV or default cache

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a26f712f6083269dda551352fde26c