### PR TITLE
feat: allow configurable AI models

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -26,10 +26,11 @@
       </div>
       <div class="kv-editor">
         <h3>Модел за анализ</h3>
-        <select id="model-select">
+        <select id="provider-select">
           <option value="gemini">Gemini</option>
           <option value="openai">OpenAI</option>
         </select>
+        <select id="model-select"></select>
         <button id="save-model" class="cta-button">Запази модел</button>
       </div>
       <h2>Ключове в KV</h2>

--- a/worker.test.js
+++ b/worker.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import worker, { resizeImage, fileToBase64, corsHeaders, getAIProvider } from './worker.js';
+import worker, { resizeImage, fileToBase64, corsHeaders, getAIProvider, getAIModel, callOpenAIAPI, callGeminiAPI } from './worker.js';
 import { KV_DATA } from './kv-data.js';
 
 test('resizeImage връща грешка при твърде голям файл', async () => {
@@ -63,6 +63,40 @@ test('getAIProvider може да избира OpenAI', async () => {
 test('getAIProvider чете стойност от KV', async () => {
   const env = { iris_rag_kv: { get: async () => 'openai' } };
   assert.equal(await getAIProvider(env), 'openai');
+});
+
+test('getAIModel връща стойност по подразбиране според доставчика', async () => {
+  assert.equal(await getAIModel({ AI_PROVIDER: 'openai' }), 'gpt-4o');
+  assert.equal(await getAIModel({ AI_PROVIDER: 'gemini' }), 'gemini-1.5-pro');
+});
+
+test('getAIModel може да чете от env и KV', async () => {
+  assert.equal(await getAIModel({ AI_MODEL: 'gpt-4o-mini' }), 'gpt-4o-mini');
+  const env = { iris_rag_kv: { get: async () => 'gemini-1.5-flash' } };
+  assert.equal(await getAIModel(env), 'gemini-1.5-flash');
+});
+
+test('Изборът OpenAI/gpt-4o-mini се подава към API', async () => {
+  const env = { openai_api_key: 'key' };
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url, options) => {
+    const body = JSON.parse(options.body);
+    assert.equal(body.model, 'gpt-4o-mini');
+    return new Response(JSON.stringify({ choices: [{ message: { content: 'ok' } }] }), { status: 200 });
+  };
+  await callOpenAIAPI('gpt-4o-mini', 'p', {}, 'a', 'b', env, false);
+  globalThis.fetch = originalFetch;
+});
+
+test('Изборът Gemini/gemini-1.5-flash се подава към API', async () => {
+  const env = { gemini_api_key: 'key' };
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url, options) => {
+    assert.ok(url.includes('gemini-1.5-flash-latest'));
+    return new Response(JSON.stringify({ candidates: [{ content: { parts: [{ text: 'ok' }] } }] }), { status: 200 });
+  };
+  await callGeminiAPI('gemini-1.5-flash', 'p', {}, 'a', 'b', env, false);
+  globalThis.fetch = originalFetch;
 });
 
 test('/admin/keys изисква Basic Auth', async () => {


### PR DESCRIPTION
## Summary
- добавени падащи списъци в админ панела за избор на AI доставчик и модел
- работникът чете AI_PROVIDER и AI_MODEL и подава модела динамично към съответния API
- разширени тестове за новата логика и за коректното използване на избраните модели

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a27860142883269cbe5af01b57e0d5