### PR TITLE
Replace localStorage with KV storage

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -405,12 +405,12 @@ async function handleAnalysisRequest(request, env) {
             throw e;
         }
 
-        if (typeof localStorage !== 'undefined') {
+        if (env.iris_rag_kv) {
             try {
-                localStorage.setItem('lastAnalysis', JSON.stringify(parsedAnalysis));
-                localStorage.setItem('holistic_analysis', parsedAnalysis.holistic_analysis);
+                await env.iris_rag_kv.put('lastAnalysis', JSON.stringify(parsedAnalysis));
+                await env.iris_rag_kv.put('holistic_analysis', parsedAnalysis.holistic_analysis);
             } catch (e) {
-                log('Неуспешен запис в localStorage:', e.message);
+                log('Неуспешен запис в KV:', e.message);
             }
         }
 

--- a/worker.test.js
+++ b/worker.test.js
@@ -3,6 +3,12 @@ import assert from 'node:assert/strict';
 import worker, { resizeImage, fileToBase64, corsHeaders, getAIProvider, getAIModel, callOpenAIAPI, callGeminiAPI } from './worker.js';
 import { KV_DATA } from './kv-data.js';
 
+test('Worker не използва браузърни API', () => {
+  assert.equal(typeof globalThis.window, 'undefined');
+  assert.equal(typeof globalThis.document, 'undefined');
+  assert.equal(typeof globalThis.localStorage, 'undefined');
+});
+
 test('resizeImage връща грешка при твърде голям файл', async () => {
   const bigBuffer = Buffer.alloc(6 * 1024 * 1024, 0); // 6MB
   const bigFile = new File([bigBuffer], 'big.jpg', { type: 'image/jpeg' });


### PR DESCRIPTION
## Summary
- Replace localStorage writes with KV storage in worker
- Add test verifying worker does not rely on browser APIs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a27bdb3140832695955bc47d5b712d