### PR TITLE
Handle space-separated CORS origins

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -590,7 +590,10 @@ function corsHeaders(request, env = {}, additionalHeaders = {}) {
 
     // Cloudflare secrets са низове, затова използваме split.
     // Позволява множество разрешени адреси, разделени със запетая.
-    const allowedOrigins = (env.ALLOWED_ORIGINS || env.allowed_origin || "*").split(",");
+    const allowedOrigins = (env.ALLOWED_ORIGINS || env.allowed_origin || "*")
+        .split(",")
+        .map(o => o.trim())
+        .filter(Boolean);
 
     let origin = "null"; // По подразбиране блокираме
     if (allowedOrigins.includes("*")) {

--- a/worker.test.js
+++ b/worker.test.js
@@ -39,6 +39,14 @@ test('corsHeaders позволява конкретен домейн', () => {
   assert.equal(headers.get('Vary'), 'Origin');
 });
 
+test('corsHeaders обработва домейни с интервали', () => {
+  const request = new Request('https://api.example', { headers: { Origin: 'https://a.com' }});
+  const env = { allowed_origin: 'https://a.com, https://b.com' };
+  const headers = corsHeaders(request, env);
+  assert.equal(headers.get('Access-Control-Allow-Origin'), 'https://a.com');
+  assert.equal(headers.get('Vary'), 'Origin');
+});
+
 test('corsHeaders връща null за неразрешен домейн', () => {
   const request = new Request('https://api.example', { headers: { Origin: 'https://evil.example' }});
   const headers = corsHeaders(request, { allowed_origin: 'https://myapp.example' });


### PR DESCRIPTION
## Summary
- trim and filter allowed origins in `corsHeaders` for robust CORS matching
- add test covering `allowed_origin` with spaces

## Testing
- `node --test --test-name-pattern=corsHeaders worker.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68a27be59f288326af82a770fd4f7938