### PR TITLE
Обработка на липсващ OpenAI API ключ

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -340,6 +340,12 @@ async function handleAnalysisRequest(request, env) {
     const model = await getAIModel(env);
     try {
         log("Получена е нова заявка за анализ.");
+        if (provider === "openai" && !env.openai_api_key) {
+            return new Response("OpenAI API ключът липсва", {
+                status: 400,
+                headers: corsHeaders(request, env, { 'Content-Type': 'text/plain; charset=utf-8' })
+            });
+        }
         const formData = await request.formData();
 
         const leftEyeFile = formData.get("left-eye");

--- a/worker.test.js
+++ b/worker.test.js
@@ -113,6 +113,14 @@ test('Изборът Gemini/gemini-1.5-flash се подава към API', asyn
   globalThis.fetch = originalFetch;
 });
 
+test('handleAnalysisRequest връща 400 при празен OpenAI API ключ', async () => {
+  const req = new Request('https://example.com/analyze', { method: 'POST' });
+  const env = { AI_PROVIDER: 'openai', openai_api_key: '' };
+  const res = await worker.fetch(req, env);
+  assert.equal(res.status, 400);
+  assert.equal(await res.text(), 'OpenAI API ключът липсва');
+});
+
 test('/admin/keys изисква Basic Auth', async () => {
   const reqNoAuth = new Request('https://example.com/admin/keys');
   const resNoAuth = await worker.fetch(reqNoAuth, {});


### PR DESCRIPTION
## Резюме
- `handleAnalysisRequest` връща 400, ако няма OpenAI API ключ
- Добавен тест за сценарий с празен ключ

## Тестове
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a27cc36b788326bc0350c0f6c299a5