### PR TITLE
feat: add caching for RAG data

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -518,24 +518,48 @@ async function fetchExternalInfo(query) {
 }
 
 // --- RAG ИЗВЛИЧАНЕ ОТ KV ---
-async function fetchRagData(keys, env) {
+export async function fetchRagData(keys, env) {
     if (!Array.isArray(keys) || keys.length === 0) {
         return {};
     }
     const { iris_rag_kv } = env;
     if (!iris_rag_kv) throw new Error("KV Namespace 'iris_rag_kv' не е свързан с този Worker.");
 
-    const promises = keys.map(key => iris_rag_kv.get(key, 'json'));
-    const results = await Promise.all(promises);
-    
+    const cache = caches.default;
+    const ttl = parseInt(env.RAG_CACHE_TTL, 10) || 300;
     const data = {};
-    results.forEach((value, index) => {
-        if (value) {
-            data[keys[index]] = value;
-        } else {
-            console.warn(`Ключ '${keys[index]}' не е намерен в KV базата.`);
+
+    const entries = await Promise.all(keys.map(async key => {
+        const cacheKey = `rag:${key}`;
+        let value;
+
+        const cached = await cache.match(cacheKey);
+        if (cached) {
+            try {
+                value = await cached.json();
+            } catch (e) {
+                console.warn('Грешка при четене от кеша за ключ', key, e);
+            }
         }
-    });
+
+        if (!value) {
+            value = await iris_rag_kv.get(key, 'json');
+            if (value) {
+                await cache.put(cacheKey, new Response(JSON.stringify(value), {
+                    headers: { 'Cache-Control': `max-age=${ttl}` }
+                }));
+            } else {
+                console.warn(`Ключ '${key}' не е намерен в KV базата.`);
+            }
+        }
+
+        return value ? [key, value] : null;
+    }));
+
+    for (const entry of entries) {
+        if (entry) data[entry[0]] = entry[1];
+    }
+
     return data;
 }
 

--- a/worker.test.js
+++ b/worker.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import worker, { resizeImage, fileToBase64, corsHeaders, getAIProvider, getAIModel, callOpenAIAPI, callGeminiAPI } from './worker.js';
+import worker, { resizeImage, fileToBase64, corsHeaders, getAIProvider, getAIModel, callOpenAIAPI, callGeminiAPI, fetchRagData } from './worker.js';
 import { KV_DATA } from './kv-data.js';
 
 test('Worker не използва браузърни API', () => {
@@ -173,5 +173,28 @@ test('/admin/sync синхронизира данни', async () => {
   const expectedKeys = Object.keys(KV_DATA).sort();
   assert.deepEqual(body.updated.sort(), expectedKeys);
   assert.deepEqual(Object.keys(store).sort(), expectedKeys);
+});
+
+test('fetchRagData използва кеша при второ извикване', async () => {
+  const store = new Map();
+  globalThis.caches = {
+    default: {
+      match: async key => store.get(key) || null,
+      put: async (key, res) => { store.set(key, res); }
+    }
+  };
+  let kvCalls = 0;
+  const env = {
+    iris_rag_kv: {
+      get: async () => { kvCalls++; return { v: 1 }; }
+    },
+    RAG_CACHE_TTL: '60'
+  };
+  const first = await fetchRagData(['a'], env);
+  assert.equal(kvCalls, 1);
+  const second = await fetchRagData(['a'], env);
+  assert.equal(kvCalls, 1);
+  assert.deepEqual(first, second);
+  delete globalThis.caches;
 });
 


### PR DESCRIPTION
## Summary
- cache RAG knowledge lookups in `caches.default` with configurable TTL
- add unit test ensuring cache usage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a27d0728d083268a2db62c5fe7a3e8