### PR TITLE
Преименуване на resizeImage на validateImageSize

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -602,18 +602,13 @@ function formatUserData(data) {
     `;
 }
 
-// ПРЕПОРЪКА #3: Преименувана функция за по-голяма яснота
+// Проверява дали изображението не надвишава максималния допустим размер.
 async function validateImageSize(file, env = {}, maxBytes = 5 * 1024 * 1024) {
     const log = (...args) => debugLog(env, ...args);
     log(`Валидиране на файл: ${file.name}, размер: ${file.size} байта.`);
     if (file.size > maxBytes) {
         throw new Error(`Файлът ${file.name} (${(file.size / 1024 / 1024).toFixed(2)}MB) надвишава максималния размер от ${maxBytes / 1024 / 1024}MB.`);
     }
-    return file;
-}
-
-async function resizeImage(file, env = {}, maxBytes = 5 * 1024 * 1024) {
-    await validateImageSize(file, env, maxBytes);
     return file;
 }
 
@@ -677,4 +672,4 @@ function corsHeaders(request, env = {}, additionalHeaders = {}) {
     return new Headers(headers);
 }
 
-export { resizeImage, fileToBase64, corsHeaders, callOpenAIAPI, callGeminiAPI };
+export { validateImageSize, fileToBase64, corsHeaders, callOpenAIAPI, callGeminiAPI };

--- a/worker.test.js
+++ b/worker.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import worker, { resizeImage, fileToBase64, corsHeaders, getAIProvider, getAIModel, callOpenAIAPI, callGeminiAPI, fetchRagData } from './worker.js';
+import worker, { validateImageSize, fileToBase64, corsHeaders, getAIProvider, getAIModel, callOpenAIAPI, callGeminiAPI, fetchRagData } from './worker.js';
 import { KV_DATA } from './kv-data.js';
 
 test('Worker не използва браузърни API', () => {
@@ -14,10 +14,10 @@ test('ROLE_PROMPT съдържа инструкция за допълнител�
   assert.ok(prompt.includes('Ако липсва информация, опиши какви допълнителни данни са нужни.'));
 });
 
-test('resizeImage връща грешка при твърде голям файл', async () => {
+test('validateImageSize връща грешка при твърде голям файл', async () => {
   const bigBuffer = Buffer.alloc(6 * 1024 * 1024, 0); // 6MB
   const bigFile = new File([bigBuffer], 'big.jpg', { type: 'image/jpeg' });
-  await assert.rejects(() => resizeImage(bigFile));
+  await assert.rejects(() => validateImageSize(bigFile));
 });
 
 test('fileToBase64 работи за малък файл', async () => {


### PR DESCRIPTION
## Обобщение
- преименувана е помощната функция за размер на изображение на `validateImageSize` и премахната стaraта `resizeImage`
- обновени са импорта и тестовете за новото име

## Тестове
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a28bd566348326a51f742969118eaf