### PR TITLE
feat: добави Access-Control-Max-Age в CORS

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -655,6 +655,7 @@ function corsHeaders(request, env = {}, additionalHeaders = {}) {
         "Access-Control-Allow-Origin": origin,
         "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
         "Access-Control-Allow-Headers": "Content-Type, Authorization",
+        "Access-Control-Max-Age": "86400",
         ...additionalHeaders,
     };
 

--- a/worker.test.js
+++ b/worker.test.js
@@ -71,6 +71,12 @@ test('corsHeaders включва всички методи', () => {
   assert.equal(headers.get('Access-Control-Allow-Methods'), 'GET, POST, PUT, DELETE, OPTIONS');
 });
 
+test('corsHeaders добавя Access-Control-Max-Age', () => {
+  const request = new Request('https://api.example', { headers: { Origin: 'https://foo.example' }});
+  const headers = corsHeaders(request, { allowed_origin: '*' });
+  assert.equal(headers.get('Access-Control-Max-Age'), '86400');
+});
+
 test('getAIProvider избира "gemini" по подразбиране', async () => {
   assert.equal(await getAIProvider({}), 'gemini');
 });


### PR DESCRIPTION
## Summary
- добавен Access-Control-Max-Age: 86400 в corsHeaders
- разширени тестове за валидиране на новото заглавие

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a28bdda1c0832685c80e09348df098