### PR TITLE
Добавени fallbacks за API ключове и обновена документация

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,13 +80,28 @@ AI_MODEL_EXTENDED = "gpt-4o" # примерна стойност
 
 ```toml
 [vars]
-openai_api_key = "YOUR_KEY"
+openai_api_key = "YOUR_KEY"  # или използвайте OPENAI_API_KEY
 ```
 
 или чрез командата:
 
 ```bash
 wrangler secret put openai_api_key
+```
+
+## Gemini API ключ
+
+За Gemini задайте ключа по аналогичен начин:
+
+```toml
+[vars]
+gemini_api_key = "YOUR_KEY"  # или използвайте GEMINI_API_KEY
+```
+
+или чрез командата:
+
+```bash
+wrangler secret put gemini_api_key
 ```
 
 ## Допълнителни бележки

--- a/admin.js
+++ b/admin.js
@@ -40,7 +40,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   async function hasOpenAIKey() {
     try {
-      const res = await fetch(`${WORKER_BASE_URL}/admin/get?key=OPENAI_API_KEY`, {
+      const res = await fetch(`${WORKER_BASE_URL}/admin/get?key=openai_api_key`, {
         headers: {
           'Content-Type': 'application/json',
           Authorization: 'Basic ' + btoa('admin:admin')

--- a/worker.js
+++ b/worker.js
@@ -426,7 +426,7 @@ async function handleAnalysisRequest(request, env) {
     const model = await getAIModel(env);
     try {
         log("Получена е нова заявка за анализ.");
-        if (provider === "openai" && !env.openai_api_key) {
+        if (provider === "openai" && !(env.openai_api_key || env.OPENAI_API_KEY)) {
             return new Response("OpenAI API ключът липсва", {
                 status: 400,
                 headers: corsHeaders(request, env, { 'Content-Type': 'text/plain; charset=utf-8' })
@@ -522,7 +522,7 @@ async function handleAnalysisRequest(request, env) {
 
 // --- AI API ИНТЕГРАЦИИ ---
 async function callGeminiAPI(model, prompt, options, leftEyeBase64, rightEyeBase64, env, expectJson = true) {
-    const apiKey = env.gemini_api_key;
+    const apiKey = env.gemini_api_key || env.GEMINI_API_KEY;
     if (!apiKey) throw new Error("API ключът за Gemini не е конфигуриран.");
     const modelName = model.endsWith('-latest') ? model : `${model}-latest`;
     const url = `https://generativelanguage.googleapis.com/v1beta/models/${modelName}:generateContent?key=${apiKey}`;
@@ -564,7 +564,7 @@ async function callGeminiAPI(model, prompt, options, leftEyeBase64, rightEyeBase
 }
 
 async function callOpenAIAPI(model, prompt, options, leftEyeBase64, rightEyeBase64, env, expectJson = true) {
-    const apiKey = env.openai_api_key;
+    const apiKey = env.openai_api_key || env.OPENAI_API_KEY;
     if (!apiKey) throw new Error("API ключът за OpenAI не е конфигуриран.");
     const url = "https://api.openai.com/v1/chat/completions";
 


### PR DESCRIPTION
## Обобщение
- Добавен fallback за OpenAI и Gemini API ключове в worker.js
- Коригирано търсенето на OpenAI ключ в admin.js
- Обновена документация за имената на променливите и добавен раздел за Gemini ключ

## Тестване
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a32ddcb5808326b63dd5458b164f0e