### PR TITLE
chore: manage API keys as secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,20 +74,16 @@ Gemini).
 AI_MODEL_EXTENDED = "gpt-4o" # примерна стойност
 ```
 
-## OpenAI API ключ
+## API ключове
 
-За да използвате моделите на OpenAI, задайте API ключа в `wrangler.toml` или като секрет:
-
-```toml
-[vars]
-openai_api_key = "YOUR_KEY"
-```
-
-или чрез командата:
+За достъп до моделите на Gemini и OpenAI задайте ключовете като секрети:
 
 ```bash
+wrangler secret put gemini_api_key
 wrangler secret put openai_api_key
 ```
+
+При изпълнение ще бъдете подканени да въведете стойността на съответния ключ.
 
 ## Допълнителни бележки
 - Логовете не съдържат чувствителни данни; отговорите от AI се съкращават.

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -5,7 +5,5 @@ compatibility_date = "2024-01-01"
 kv_namespaces = [{ binding = "iris_rag_kv", id = "..." }]
 
 [vars]
-gemini_api_key = ""
-openai_api_key = ""
 allowed_origin = "*"
 DEBUG = "false" # Set to "true" for detailed logging


### PR DESCRIPTION
## Summary
- remove API keys from Wrangler configuration
- document how to set Gemini and OpenAI keys as secrets

## Testing
- `npm test`
- `npx wrangler secret put gemini_api_key` *(fails: fetch failed)*
- `npx wrangler secret put openai_api_key` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a32e52108883269599746c7b1d27f1