### PR TITLE
chore: use wrangler secrets for API keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,32 +73,24 @@ Gemini).
 [vars]
 AI_MODEL_EXTENDED = "gpt-4o" # примерна стойност
 ```
+## Задаване на секрети
 
-## OpenAI API ключ
+API ключовете се съхраняват като Cloudflare секрети. Задайте ги чрез:
 
-За да използвате моделите на OpenAI, задайте API ключа в `wrangler.toml` или като секрет:
-
-```toml
-[vars]
-openai_api_key = "YOUR_KEY"  # или използвайте OPENAI_API_KEY
+```bash
+wrangler secret put openai_api_key
+wrangler secret put gemini_api_key
 ```
 
-или чрез командата:
+Въведете стойностите, когато бъдете подканени.
+
+## OpenAI API ключ
 
 ```bash
 wrangler secret put openai_api_key
 ```
 
 ## Gemini API ключ
-
-За Gemini задайте ключа по аналогичен начин:
-
-```toml
-[vars]
-gemini_api_key = "YOUR_KEY"  # или използвайте GEMINI_API_KEY
-```
-
-или чрез командата:
 
 ```bash
 wrangler secret put gemini_api_key

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -5,7 +5,5 @@ compatibility_date = "2024-01-01"
 kv_namespaces = [{ binding = "iris_rag_kv", id = "..." }]
 
 [vars]
-gemini_api_key = ""
-openai_api_key = ""
 allowed_origin = "*"
 DEBUG = "false" # Set to "true" for detailed logging


### PR DESCRIPTION
## Summary
- remove API keys from wrangler.toml vars
- document secret setup in README

## Testing
- `npm test`
- `wrangler secret put gemini_api_key` *(fails: fetch failed)*
- `wrangler secret put openai_api_key` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a3411fd05483269e4e9b44aa096057