### PR TITLE
Проверка за Gemini API ключ и тест

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -426,6 +426,12 @@ async function handleAnalysisRequest(request, env) {
     const model = await getAIModel(env);
     try {
         log("Получена е нова заявка за анализ.");
+        if (provider === "gemini" && !(env.gemini_api_key || env.GEMINI_API_KEY)) {
+            return new Response("Gemini API ключът липсва", {
+                status: 400,
+                headers: corsHeaders(request, env, { 'Content-Type': 'text/plain; charset=utf-8' })
+            });
+        }
         if (provider === "openai" && !(env.openai_api_key || env.OPENAI_API_KEY)) {
             return new Response("OpenAI API ключът липсва", {
                 status: 400,

--- a/worker.test.js
+++ b/worker.test.js
@@ -169,6 +169,14 @@ test('handleAnalysisRequest връща 400 при празен OpenAI API клю
   assert.equal(await res.text(), 'OpenAI API ключът липсва');
 });
 
+test('handleAnalysisRequest връща 400 при липсващ Gemini API ключ', async () => {
+  const req = new Request('https://example.com/analyze', { method: 'POST' });
+  const env = { AI_PROVIDER: 'gemini', gemini_api_key: '' };
+  const res = await worker.fetch(req, env);
+  assert.equal(res.status, 400);
+  assert.equal(await res.text(), 'Gemini API ключът липсва');
+});
+
 test('handleAnalysisRequest връща контролирано съобщение при невалиден AI JSON', async () => {
   const buf = Buffer.alloc(10, 0);
   const form = new FormData();


### PR DESCRIPTION
## Обобщение
- Добавена е проверка за липсващ Gemini API ключ в `handleAnalysisRequest`.
- Създаден е unit тест за отговор 400 при липсващ Gemini ключ.

## Тестване
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a345dcbfc08326a8a2b2cfc3733b58