### PR TITLE
Парсиране на AI_MODEL от KV

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -130,16 +130,14 @@ export async function getAIModel(env = {}) {
     if (env.AI_MODEL) return env.AI_MODEL;
     if (env.iris_rag_kv) {
         try {
-            const val = await env.iris_rag_kv.get('AI_MODEL');
-            if (typeof val === 'string') {
-                const model = val.trim();
-                if (model) return model;
+            const val = await env.iris_rag_kv.get('AI_MODEL', 'json');
+            if (typeof val === 'string' && val.trim()) {
+                return val.trim();
             }
         } catch (e) {
             console.warn('Неуспешно извличане на AI_MODEL от KV:', e);
         }
     }
-    if (env.AI_MODEL_EXTENDED) return env.AI_MODEL_EXTENDED;
     const provider = await getAIProvider(env);
     return provider === 'openai' ? 'gpt-4o' : 'gemini-1.5-pro';
 }

--- a/worker.test.js
+++ b/worker.test.js
@@ -97,21 +97,30 @@ test('getAIModel връща стойност по подразбиране сп�
 
 test('getAIModel може да чете от env и KV', async () => {
   assert.equal(await getAIModel({ AI_MODEL: 'gpt-4o-mini' }), 'gpt-4o-mini');
-  const env = { iris_rag_kv: { get: async () => 'gemini-1.5-flash' } };
+  const env = {
+    iris_rag_kv: {
+      get: async (key, type) => {
+        assert.equal(key, 'AI_MODEL');
+        assert.equal(type, 'json');
+        return 'gemini-1.5-flash';
+      }
+    }
+  };
   assert.equal(await getAIModel(env), 'gemini-1.5-flash');
 });
 
 test('getAIModel игнорира празни или невалидни стойности от KV', async () => {
-  const emptyEnv = { iris_rag_kv: { get: async () => '' }, AI_PROVIDER: 'openai' };
+  const emptyEnv = {
+    iris_rag_kv: { get: async () => null },
+    AI_PROVIDER: 'openai'
+  };
   assert.equal(await getAIModel(emptyEnv), 'gpt-4o');
 
-  const invalidEnv = { iris_rag_kv: { get: async () => 123 }, AI_PROVIDER: 'openai' };
+  const invalidEnv = {
+    iris_rag_kv: { get: async () => 123 },
+    AI_PROVIDER: 'openai'
+  };
   assert.equal(await getAIModel(invalidEnv), 'gpt-4o');
-});
-
-test('getAIModel използва AI_MODEL_EXTENDED при липса на AI_MODEL', async () => {
-  const env = { AI_MODEL_EXTENDED: 'gpt-4o', AI_PROVIDER: 'openai' };
-  assert.equal(await getAIModel(env), 'gpt-4o');
 });
 
 test('Изборът OpenAI/gpt-4o-mini се подава към API', async () => {


### PR DESCRIPTION
## Summary
- Парсиране на AI_MODEL чрез `env.iris_rag_kv.get('AI_MODEL', 'json')` и fallback към дефолтните модели според доставчика
- Актуализирани тестове за `getAIModel` с очакване на вече парсирани стойности и отпадане на AI_MODEL_EXTENDED

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3667b09188326bccc914a663bde96