### PR TITLE
Обработка на невалидни AI_PROVIDER/AI_MODEL при парсване

### DIFF
--- a/admin.js
+++ b/admin.js
@@ -186,8 +186,25 @@ document.addEventListener('DOMContentLoaded', () => {
 
       const providerData = await providerRes.json();
       const modelData = await modelRes.json();
-      let provider = JSON.parse(providerData.value || JSON.stringify(Object.keys(MODEL_OPTIONS)[0] || 'gemini'));
-      let model = JSON.parse(modelData.value || '""');
+
+      let provider;
+      try {
+        provider = JSON.parse(providerData.value);
+      } catch (err) {
+        provider = providerData.value?.trim() || 'gemini';
+        showMessage('Невалиден формат за AI_PROVIDER: ' + err.message + '. Използвам "' + provider + '".', 'error');
+      }
+      if (!provider || !MODEL_OPTIONS[provider]) provider = 'gemini';
+
+      let model;
+      try {
+        model = JSON.parse(modelData.value);
+      } catch (err) {
+        model = modelData.value?.trim() || (MODEL_OPTIONS[provider] || [])[0];
+        showMessage('Невалиден формат за AI_MODEL: ' + err.message + '. Използвам "' + model + '".', 'error');
+      }
+      if (!model) model = (MODEL_OPTIONS[provider] || [])[0];
+
       populateProviderOptions(provider);
       const hasKey = keySet;
       if (!hasKey) {


### PR DESCRIPTION
## Summary
- добавен try/catch при парсване на AI_PROVIDER и AI_MODEL
- fallback към оригиналната стойност или дефолтни `gemini` и първия модел
- показване на съобщение при невалиден формат без блокиране на зареждането

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a36894ded083268a5a59cdbd88fb3c