### PR TITLE
Обработка на 404 и непознати статуси при AI моделите

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -563,7 +563,14 @@ async function callGeminiAPI(model, prompt, options, leftEyeBase64, rightEyeBase
     const response = await fetch(url, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(requestBody) });
     const responseData = await response.json();
 
-    if (!response.ok || !responseData.candidates?.[0]?.content.parts?.[0]?.text) {
+    if (response.status === 404) {
+        throw new Error(`Моделът ${model} не е наличен`);
+    }
+    if (!response.ok) {
+        console.error("Грешка от Gemini API:", JSON.stringify(responseData, null, 2));
+        throw new Error(`HTTP ${response.status}`);
+    }
+    if (!responseData.candidates?.[0]?.content.parts?.[0]?.text) {
         console.error("Грешка от Gemini API:", JSON.stringify(responseData, null, 2));
         throw new Error("Неуспешна или невалидна заявка към Gemini API.");
     }
@@ -600,8 +607,15 @@ async function callOpenAIAPI(model, prompt, options, leftEyeBase64, rightEyeBase
 
     const response = await fetch(url, { method: 'POST', headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${apiKey}` }, body: JSON.stringify(requestBody) });
     const responseData = await response.json();
-    
-    if (!response.ok || !responseData.choices?.[0]?.message?.content) {
+
+    if (response.status === 404) {
+        throw new Error(`Моделът ${model} не е наличен`);
+    }
+    if (!response.ok) {
+        console.error("Грешка от OpenAI API:", JSON.stringify(responseData, null, 2));
+        throw new Error(`HTTP ${response.status}`);
+    }
+    if (!responseData.choices?.[0]?.message?.content) {
         console.error("Грешка от OpenAI API:", JSON.stringify(responseData, null, 2));
         throw new Error("Неуспешна или невалидна заявка към OpenAI API.");
     }

--- a/worker.test.js
+++ b/worker.test.js
@@ -170,6 +170,50 @@ test('callGeminiAPI изпраща generationConfig.maxOutputTokens', async () =
   globalThis.fetch = originalFetch;
 });
 
+test('callOpenAIAPI връща грешка при 404', async () => {
+  const env = { openai_api_key: 'key' };
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => new Response(JSON.stringify({}), { status: 404 });
+  await assert.rejects(
+    () => callOpenAIAPI('gpt-4o', 'p', {}, 'a', 'b', env, false),
+    /Моделът gpt-4o не е наличен/
+  );
+  globalThis.fetch = originalFetch;
+});
+
+test('callOpenAIAPI логва JSON и хвърля HTTP статус', async () => {
+  const env = { openai_api_key: 'key' };
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => new Response(JSON.stringify({ error: 'x' }), { status: 500 });
+  await assert.rejects(
+    () => callOpenAIAPI('gpt-4o', 'p', {}, 'a', 'b', env, false),
+    /HTTP 500/
+  );
+  globalThis.fetch = originalFetch;
+});
+
+test('callGeminiAPI връща грешка при 404', async () => {
+  const env = { gemini_api_key: 'key' };
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => new Response(JSON.stringify({}), { status: 404 });
+  await assert.rejects(
+    () => callGeminiAPI('gemini-1.5-flash', 'p', {}, 'a', 'b', env, false),
+    /Моделът gemini-1.5-flash не е наличен/
+  );
+  globalThis.fetch = originalFetch;
+});
+
+test('callGeminiAPI логва JSON и хвърля HTTP статус', async () => {
+  const env = { gemini_api_key: 'key' };
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => new Response(JSON.stringify({ error: 'x' }), { status: 500 });
+  await assert.rejects(
+    () => callGeminiAPI('gemini-1.5-pro', 'p', {}, 'a', 'b', env, false),
+    /HTTP 500/
+  );
+  globalThis.fetch = originalFetch;
+});
+
 test('handleAnalysisRequest връща 400 при празен OpenAI API ключ', async () => {
   const req = new Request('https://example.com/analyze', { method: 'POST' });
   const env = { AI_PROVIDER: 'openai', openai_api_key: '' };


### PR DESCRIPTION
## Резюме
- добавена проверка за `response.status === 404` и специфична грешка за липсващ модел
- логване на пълния JSON при други неуспешни статуси с хвърляне `HTTP <status>`
- нови тестове за грешки на OpenAI и Gemini API

## Тестване
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a398d37f148326bed044ffdd1c4c21