### PR TITLE
feat: add admin secret check

### DIFF
--- a/admin.js
+++ b/admin.js
@@ -87,7 +87,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   async function hasOpenAIKey() {
     try {
-      const res = await fetch(`${WORKER_BASE_URL}/admin/get?key=openai_api_key`, {
+      const res = await fetch(`${WORKER_BASE_URL}/admin/secret`, {
         headers: {
           'Content-Type': 'application/json',
           Authorization: 'Basic ' + btoa('admin:admin')
@@ -95,11 +95,7 @@ document.addEventListener('DOMContentLoaded', () => {
       });
       if (!res.ok) return false;
       const data = await res.json();
-      try {
-        return !!JSON.parse(data.value || '""');
-      } catch {
-        return !!data.value;
-      }
+      return !!data.exists;
     } catch {
       return false;
     }

--- a/worker.js
+++ b/worker.js
@@ -245,6 +245,12 @@ async function handleAdmin(request, env) {
     if (url.pathname === '/admin/keys' && request.method === 'GET') {
         return adminKeys(env, request);
     }
+    if (url.pathname === '/admin/secret' && request.method === 'GET') {
+        const exists = Boolean(env.openai_api_key || env.OPENAI_API_KEY);
+        return new Response(JSON.stringify({ exists }), {
+            headers: corsHeaders(request, env, { 'Content-Type': 'application/json' })
+        });
+    }
     if (url.pathname === '/admin/get' && request.method === 'GET') {
         const key = url.searchParams.get('key');
         return adminGet(env, request, key);

--- a/worker.test.js
+++ b/worker.test.js
@@ -271,6 +271,29 @@ test('/admin/keys изисква Basic Auth', async () => {
 });
 
 
+test('/admin/secret връща наличност на OpenAI ключ и изисква Basic Auth', async () => {
+  const reqNoAuth = new Request('https://example.com/admin/secret');
+  const resNoAuth = await worker.fetch(reqNoAuth, {});
+  assert.equal(resNoAuth.status, 401);
+
+  const auth = 'Basic ' + Buffer.from('admin:pass').toString('base64');
+  const envWithKey = { ADMIN_USER: 'admin', ADMIN_PASS: 'pass', openai_api_key: 'k' };
+  const reqAuth1 = new Request('https://example.com/admin/secret', {
+    headers: { Authorization: auth }
+  });
+  const resAuth1 = await worker.fetch(reqAuth1, envWithKey);
+  assert.equal(resAuth1.status, 200);
+  assert.deepEqual(await resAuth1.json(), { exists: true });
+
+  const envWithoutKey = { ADMIN_USER: 'admin', ADMIN_PASS: 'pass' };
+  const reqAuth2 = new Request('https://example.com/admin/secret', {
+    headers: { Authorization: auth }
+  });
+  const resAuth2 = await worker.fetch(reqAuth2, envWithoutKey);
+  assert.equal(resAuth2.status, 200);
+  assert.deepEqual(await resAuth2.json(), { exists: false });
+});
+
 test('/admin/sync синхронизира данни', async () => {
   const auth = 'Basic ' + Buffer.from('admin:pass').toString('base64');
   const store = {};


### PR DESCRIPTION
## Summary
- add `/admin/secret` route that returns presence of OpenAI API key and is secured with Basic Auth
- update admin page to query new secret endpoint instead of exposing key retrieval
- cover the new admin route with tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a39d3fa9e483269b58140e867d7763