### PR TITLE
feat: add gemini key check

### DIFF
--- a/admin.js
+++ b/admin.js
@@ -101,6 +101,26 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
+  async function hasGeminiKey() {
+    try {
+      const res = await fetch(`${WORKER_BASE_URL}/admin/secret/gemini`, {
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Basic ' + btoa('admin:admin')
+        }
+      });
+      if (!res.ok) return false;
+      const data = await res.json();
+      if (!data.exists) {
+        showMessage('Gemini API ключ липсва. Задайте го чрез `wrangler secret put gemini_api_key`.', 'error');
+      }
+      return !!data.exists;
+    } catch {
+      showMessage('Грешка при проверка за Gemini API ключ.', 'error');
+      return false;
+    }
+  }
+
   function showLoading() {
     loadingEl.style.display = 'flex';
   }
@@ -181,6 +201,8 @@ document.addEventListener('DOMContentLoaded', () => {
         fetch(`${WORKER_BASE_URL}/admin/get?key=AI_MODEL`, { headers }),
         hasOpenAIKey()
       ]);
+
+      await hasGeminiKey();
 
       if (optionsRes.status === 404) {
         MODEL_OPTIONS = JSON.parse(JSON.stringify(DEFAULT_MODEL_OPTIONS));

--- a/worker.js
+++ b/worker.js
@@ -245,6 +245,12 @@ async function handleAdmin(request, env) {
     if (url.pathname === '/admin/keys' && request.method === 'GET') {
         return adminKeys(env, request);
     }
+    if (url.pathname === '/admin/secret/gemini' && request.method === 'GET') {
+        const exists = Boolean(env.gemini_api_key || env.GEMINI_API_KEY);
+        return new Response(JSON.stringify({ exists }), {
+            headers: corsHeaders(request, env, { 'Content-Type': 'application/json' })
+        });
+    }
     if (url.pathname === '/admin/secret' && request.method === 'GET') {
         const exists = Boolean(env.openai_api_key || env.OPENAI_API_KEY);
         return new Response(JSON.stringify({ exists }), {

--- a/worker.test.js
+++ b/worker.test.js
@@ -294,6 +294,29 @@ test('/admin/secret връща наличност на OpenAI ключ и изи
   assert.deepEqual(await resAuth2.json(), { exists: false });
 });
 
+test('/admin/secret/gemini връща наличност на Gemini ключ и изисква Basic Auth', async () => {
+  const reqNoAuth = new Request('https://example.com/admin/secret/gemini');
+  const resNoAuth = await worker.fetch(reqNoAuth, {});
+  assert.equal(resNoAuth.status, 401);
+
+  const auth = 'Basic ' + Buffer.from('admin:pass').toString('base64');
+  const envWithKey = { ADMIN_USER: 'admin', ADMIN_PASS: 'pass', gemini_api_key: 'k' };
+  const reqAuth1 = new Request('https://example.com/admin/secret/gemini', {
+    headers: { Authorization: auth }
+  });
+  const resAuth1 = await worker.fetch(reqAuth1, envWithKey);
+  assert.equal(resAuth1.status, 200);
+  assert.deepEqual(await resAuth1.json(), { exists: true });
+
+  const envWithoutKey = { ADMIN_USER: 'admin', ADMIN_PASS: 'pass' };
+  const reqAuth2 = new Request('https://example.com/admin/secret/gemini', {
+    headers: { Authorization: auth }
+  });
+  const resAuth2 = await worker.fetch(reqAuth2, envWithoutKey);
+  assert.equal(resAuth2.status, 200);
+  assert.deepEqual(await resAuth2.json(), { exists: false });
+});
+
 test('/admin/sync синхронизира данни', async () => {
   const auth = 'Basic ' + Buffer.from('admin:pass').toString('base64');
   const store = {};


### PR DESCRIPTION
## Summary
- expose `/admin/secret/gemini` to report Gemini key presence
- warn in admin panel when Gemini key is missing
- cover new route with tests including auth

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3a40b0fcc832689a5a678544e5618