### PR TITLE
Използване на Request за кеш в RAG

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -699,10 +699,10 @@ export async function fetchRagData(keys, env) {
         if (!Array.isArray(arr) || arr.length === 0) return {};
         const data = {};
         const entries = await Promise.all(arr.map(async key => {
-            const cacheKey = `rag:${key}`;
+            const cacheReq = new Request(`https://rag-cache/${key}`);
             let value;
 
-            const cached = await cache.match(cacheKey);
+            const cached = await cache.match(cacheReq);
             if (cached) {
                 try {
                     value = await cached.json();
@@ -714,9 +714,12 @@ export async function fetchRagData(keys, env) {
             if (!value) {
                 value = await iris_rag_kv.get(key, 'json');
                 if (value) {
-                    await cache.put(cacheKey, new Response(JSON.stringify(value), {
-                        headers: { 'Cache-Control': `max-age=${ttl}` }
-                    }));
+                    await cache.put(
+                        cacheReq,
+                        new Response(JSON.stringify(value), {
+                            headers: { 'Cache-Control': `max-age=${ttl}` }
+                        })
+                    );
                 } else {
                     console.warn(`Ключ '${key}' не е намерен в KV базата.`);
                 }

--- a/worker.test.js
+++ b/worker.test.js
@@ -389,8 +389,8 @@ test('fetchRagData използва кеша при второ извикван�
   const store = new Map();
   globalThis.caches = {
     default: {
-      match: async key => store.get(key) || null,
-      put: async (key, res) => { store.set(key, res); }
+      match: async req => store.get(req.url || req) || null,
+      put: async (req, res) => { store.set(req.url || req, res); }
     }
   };
   let kvCalls = 0;


### PR DESCRIPTION
## Обобщение
- Променено е кеширането на RAG данните да използва `Request` обекти с фиктивен домейн вместо низови ключове.
- Адаптиран е тестът за `fetchRagData`, за да съхранява и търси по `req.url`.

## Тестване
- `npm test`
- `curl -X POST http://localhost:8787/analyze -F left-eye=@left.jpg -F right-eye=@right.jpg` (очакван 400: липсва Gemini API ключ)


------
https://chatgpt.com/codex/tasks/task_e_68a3bb66a83c8326b80606a1a649485c