### PR TITLE
test: refine cache mock behavior

### DIFF
--- a/worker.test.js
+++ b/worker.test.js
@@ -389,8 +389,8 @@ test('fetchRagData използва кеша при второ извикван�
   const store = new Map();
   globalThis.caches = {
     default: {
-      match: async req => store.get(req.url || req) || null,
-      put: async (req, res) => { store.set(req.url || req, res); }
+      match: async req => store.get(req.url) || null,
+      put: async (req, res) => { store.set(req.url, res); }
     }
   };
   let kvCalls = 0;


### PR DESCRIPTION
## Summary
- simplify cache mocks in `fetchRagData` tests to rely on request URLs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3bdd0500483268caf72dbfc7a6ab6