### PR TITLE
Добавен CSS @media блок за екрани до 480px

### DIFF
--- a/style.css
+++ b/style.css
@@ -738,3 +738,30 @@ body {
         margin-right: 0.8rem;
     }
 }
+
+/* Допълнителни оптимизации за много малки екрани */
+@media (max-width: 480px) {
+    .stepper-nav {
+        flex-direction: column;
+        align-items: flex-start;
+        justify-content: flex-start;
+    }
+
+    .step span {
+        width: 30px;
+        height: 30px;
+        font-size: 0.8rem;
+    }
+
+    .step p {
+        font-size: 0.8rem;
+    }
+
+    .form-grid {
+        gap: 0.75rem;
+    }
+
+    .card {
+        padding: 1rem;
+    }
+}


### PR DESCRIPTION
## Резюме
- Добавен @media (max-width: 480px) за вертикално подреждане на stepper-nav
- Намалени размери на step индикатора и текстовете
- Намалени gap и padding в form-grid и card

## Тестване
- `npm test`
- `npx playwright install chromium` *(неуспешно: Domain forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a5cdab733083268f01003dec1363bf