### PR TITLE
Съкратени етикети на стъпките и ellipsis стил

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,11 +35,11 @@
             <form id="iridology-form" class="card">
                 <!-- НАВИГАЦИЯ НА СТЪПКИТЕ -->
                 <ul class="stepper-nav" role="list">
-                    <li class="step active" data-step="1" role="listitem"><span>1</span><p>Основна информация</p></li>
+                    <li class="step active" data-step="1" role="listitem"><span>1</span><p>Инфо</p></li>
                     <li class="step-line" aria-hidden="true"></li>
-                    <li class="step" data-step="2" role="listitem"><span>2</span><p>Начин на живот</p></li>
+                    <li class="step" data-step="2" role="listitem"><span>2</span><p>Навици</p></li>
                     <li class="step-line" aria-hidden="true"></li>
-                    <li class="step" data-step="3" role="listitem"><span>3</span><p>Качване на снимки</p></li>
+                    <li class="step" data-step="3" role="listitem"><span>3</span><p>Снимки</p></li>
                 </ul>
 
                 <!-- СТЪПКА 1: ВЪПРОСНИК - ДЕМОГРАФСКИ И ЗДРАВНИ -->

--- a/style.css
+++ b/style.css
@@ -248,6 +248,10 @@ body {
 .step p {
     font-size: 0.9rem;
     margin-top: 0.5rem;
+    max-width: 80px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 .step.active span {
     background-color: var(--primary-color);


### PR DESCRIPTION
## Резюме
- Съкратени са текстовете на стъпките в навигацията
- Ограничена е ширината на `.step p` и е добавено `text-overflow: ellipsis`

## Тестване
- `npm test`
- `npx playwright screenshot index.html stepper-480.png --viewport-size=480,800`

------
https://chatgpt.com/codex/tasks/task_e_68a6880695848326815f50cb5e11b120