### PR TITLE
Adjust stepper navigation for narrow screens

### DIFF
--- a/style.css
+++ b/style.css
@@ -745,19 +745,21 @@ body {
 /* Допълнителни оптимизации за много малки екрани */
 @media (max-width: 480px) {
     .stepper-nav {
-        flex-direction: column;
         align-items: flex-start;
-        justify-content: flex-start;
+        flex-direction: row;
+        flex-wrap: nowrap;
+        justify-content: space-between;
+        overflow-x: auto;
     }
 
     .step span {
         width: 30px;
         height: 30px;
-        font-size: 0.8rem;
+        font-size: 0.75rem;
     }
 
     .step p {
-        font-size: 0.8rem;
+        font-size: 0.75rem;
     }
 
     .form-grid {


### PR DESCRIPTION
## Summary
- Make stepper navigation horizontal on phones and allow scrolling
- Reduce step icon and label font sizes for better fit

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a687e32fe48326aaed69d60257841e