### PR TITLE
Външна информация чрез Google Custom Search

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,16 @@ gemini_api_key = "YOUR_KEY"  # или използвайте GEMINI_API_KEY
 wrangler secret put gemini_api_key
 ```
 
+## Google Custom Search API
+
+За външни източници се използва Google Custom Search. Настройте ключ и идентификатор:
+
+```toml
+[vars]
+GOOGLE_API_KEY = "demo-key"
+GOOGLE_CX = "demo-cx"
+```
+
 ## Първоначално конфигуриране
 
 1. Отворете `admin.html` в браузър.


### PR DESCRIPTION
## Резюме
- използван е Google Custom Search API вместо Wikipedia за външни източници
- добавена е конфигурация за `GOOGLE_API_KEY` и `GOOGLE_CX` в README

## Тестване
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a70a694ea88326ad954aa6ba4b6258