### PR TITLE
Оптимизация на Base64 конвертиране и тестове

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -793,9 +793,17 @@ async function fileToBase64(file, env = {}) {
     await validateImageSize(file, env);
     const arrayBuffer = await file.arrayBuffer();
     const bytes = new Uint8Array(arrayBuffer);
+
+    // Използваме Node Buffer ако е наличен за по-ефективно кодиране
+    if (typeof Buffer !== 'undefined') {
+        return Buffer.from(bytes).toString('base64');
+    }
+
+    const chunkSize = 8192; // 8KB
     let binary = '';
-    for (let i = 0; i < bytes.length; i++) {
-        binary += String.fromCharCode(bytes[i]);
+    for (let i = 0; i < bytes.length; i += chunkSize) {
+        const chunk = bytes.subarray(i, i + chunkSize);
+        binary += String.fromCharCode.apply(null, chunk);
     }
     return btoa(binary);
 }

--- a/worker.test.js
+++ b/worker.test.js
@@ -28,6 +28,14 @@ test('fileToBase64 работи за малък файл', async () => {
   assert.match(base64, /^[A-Za-z0-9+/=]+$/);
 });
 
+test('fileToBase64 обработва файл по-голям от 8KB', async () => {
+  const buffer = Buffer.alloc(20 * 1024, 123); // 20KB
+  const file = new File([buffer], 'chunk.jpg', { type: 'image/jpeg' });
+  const expected = buffer.toString('base64');
+  const result = await fileToBase64(file);
+  assert.equal(result, expected);
+});
+
 test('corsHeaders поддържа wildcard "*"', () => {
   const request = new Request('https://api.example', { headers: { Origin: 'https://myapp.example' }});
   const headers = corsHeaders(request, { allowed_origin: '*' });


### PR DESCRIPTION
## Summary
- Подобрено е fileToBase64 с chunk обработка (8KB) и fallback към Buffer при Node
- Добавен е тест за коректност на новата имплементация при файлове >8KB

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a70b21fab88326b492d7835e5d21ec