### PR TITLE
Remove undici dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,7 @@
         "dotenv": "^16.6.1",
         "jimp": "^0.22.12"
       },
-      "devDependencies": {
-        "undici": "^7.13.0"
-      }
+      "devDependencies": {}
     },
     "node_modules/@jimp/bmp": {
       "version": "0.22.12",
@@ -1001,16 +999,6 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
-    },
-    "node_modules/undici": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.13.0.tgz",
-      "integrity": "sha512-l+zSMssRqrzDcb3fjMkjjLGmuiiK2pMIcV++mJaAc9vhjSGpvM7h43QgP+OAMb1GImHmbPyG2tBXeuyG5iY4gA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.1"
-      }
     },
     "node_modules/utif2": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,5 @@
   "dependencies": {
     "dotenv": "^16.6.1",
     "jimp": "^0.22.12"
-  },
-  "devDependencies": {
-    "undici": "^7.13.0"
   }
 }


### PR DESCRIPTION
## Summary
- remove the unused undici dev dependency
- prune package-lock accordingly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a70c1315a88326a0282c694867d87f