### PR TITLE
Увеличи ограничението за размер на изображенията до 10MB

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -797,7 +797,7 @@ function formatUserData(data) {
 }
 
 // Проверява дали изображението не надвишава максималния допустим размер.
-async function validateImageSize(file, env = {}, maxBytes = 5 * 1024 * 1024) {
+async function validateImageSize(file, env = {}, maxBytes = 10 * 1024 * 1024) {
     const log = (...args) => debugLog(env, ...args);
     log(`Валидиране на файл: ${file.name}, размер: ${file.size} байта.`);
     if (file.size > maxBytes) {

--- a/worker.test.js
+++ b/worker.test.js
@@ -16,7 +16,7 @@ test('ROLE_PROMPT съдържа ключ missing_data', () => {
 });
 
 test('validateImageSize връща грешка при твърде голям файл', async () => {
-  const bigBuffer = Buffer.alloc(6 * 1024 * 1024, 0); // 6MB
+  const bigBuffer = Buffer.alloc(11 * 1024 * 1024, 0); // 11MB
   const bigFile = new File([bigBuffer], 'big.jpg', { type: 'image/jpeg' });
   await assert.rejects(() => validateImageSize(bigFile));
 });


### PR DESCRIPTION
## Резюме
- Увеличен е максималният размер на приетите изображения до 10MB
- Актуализиран е тестът за валидация на размера, за да отразява новото ограничение

## Тестване
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7c15eb1f88326b862e8c7d05aac2b