### PR TITLE
docs: тип за OpenAI съдържание

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -710,6 +710,7 @@ async function callOpenAIAPI(model, prompt, options, leftEye, rightEye, env, exp
     if (options.systemPrompt) {
         messages.push({ role: "system", content: options.systemPrompt });
     }
+    /** @type {Array<{type:string, text?:string, image_url?:{url:string}}>} */
     const content = [{ type: "text", text: prompt }];
     if (leftEye) {
         content.push({ type: "image_url", image_url: { url: `data:${leftEye.type};base64,${leftEye.data}` }});


### PR DESCRIPTION
## Summary
- добавен JSDoc тип за масива с content
- запазено комбиниране на MIME и Base64 за image_url

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7d15871ec8326a0fb2bc21bbc2d30