### PR TITLE
Изпращане на чист Base64 към Gemini API

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -654,13 +654,14 @@ async function callGeminiAPI(model, prompt, options, leftEye, rightEye, env, exp
     const modelName = model.endsWith('-latest') ? model : `${model}-latest`;
     const url = `https://generativelanguage.googleapis.com/v1beta/models/${modelName}:generateContent?key=${apiKey}`;
 
+    /** @type {Array<{text?:string, inline_data?:{mime_type:string, data:string}}>} */
     const parts = [{ text: prompt }];
     if (leftEye) {
-        parts.push({ inline_data: { mime_type: leftEye.type, data: `data:${leftEye.type};base64,${leftEye.data}` }});
+        parts.push({ inline_data: { mime_type: leftEye.type, data: leftEye.data } });
         parts.push({ text: "\n(Снимка на ЛЯВО око)" });
     }
     if (rightEye) {
-        parts.push({ inline_data: { mime_type: rightEye.type, data: `data:${rightEye.type};base64,${rightEye.data}` }});
+        parts.push({ inline_data: { mime_type: rightEye.type, data: rightEye.data } });
         parts.push({ text: "\n(Снимка на ДЯСНО око)" });
     }
 

--- a/worker.test.js
+++ b/worker.test.js
@@ -154,7 +154,7 @@ test('Изборът Gemini/gemini-1.5-flash се подава към API', asyn
     assert.ok(url.includes('gemini-1.5-flash-latest'));
     const body = JSON.parse(options.body);
     assert.equal(body.contents[0].parts[1].inline_data.mime_type, 'image/png');
-    assert.equal(body.contents[0].parts[1].inline_data.data, 'data:image/png;base64,a');
+    assert.equal(body.contents[0].parts[1].inline_data.data, 'a');
     return new Response(JSON.stringify({ candidates: [{ content: { parts: [{ text: 'ok' }] } }] }), { status: 200 });
   };
   await callGeminiAPI('gemini-1.5-flash', 'p', {}, { data: 'a', type: 'image/png' }, { data: 'b', type: 'image/png' }, env, false);


### PR DESCRIPTION
## Резюме
- Подадените към Gemini изображения вече използват само Base64 стойности
- Добавен JSDoc тип за parts в callGeminiAPI
- Актуализиран тест за новия формат на изображението

## Тестване
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7d15466b48326925c6b8b02456f68