### PR TITLE
Агрегирано предупреждение за липсващи RAG ключове

### DIFF
--- a/worker.test.js
+++ b/worker.test.js
@@ -412,3 +412,17 @@ test('fetchRagData извлича само данни за DISPOSITION_ACIDITY',
   delete globalThis.caches;
 });
 
+test('fetchRagData логва едно предупреждение за липсващи ключове', async () => {
+  globalThis.caches = { default: { match: async () => null, put: async () => {} } };
+  const env = { iris_rag_kv: { get: async () => null } };
+  const warnings = [];
+  const originalWarn = console.warn;
+  console.warn = msg => warnings.push(msg);
+
+  await fetchRagData(['a', 'b'], env);
+
+  console.warn = originalWarn;
+  assert.deepEqual(warnings, ['Липсващи RAG ключове: a, b']);
+  delete globalThis.caches;
+});
+


### PR DESCRIPTION
## Резюме
- Събира липсващите RAG ключове и ги логва в едно предупреждение
- Добавен тест за агрегираното предупреждение

## Тестване
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a873b3f6b883268a55612767ae57db