### PR TITLE
Обработка на AI грешки при RAG ключове

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -550,6 +550,12 @@ async function handleAnalysisRequest(request, env) {
         const cleaned = extractJsonArray(keysResponse) || keysResponse;
         try {
             ragKeys = JSON.parse(cleaned);
+            if (ragKeys && typeof ragKeys === 'object' && Object.hasOwn(ragKeys, 'error')) {
+                const msg = ragKeys.error;
+                log('AI върна грешка:', msg);
+                console.info('AI върна грешка:', msg);
+                return jsonError(msg, 400, request, env);
+            }
         } catch (parseError) {
             const logMsg = "Суров отговор от AI при грешка в парсването:";
             log(logMsg, keysResponse);


### PR DESCRIPTION
## Резюме
- добавена проверка за поле `error` в JSON отговорите при извличане на RAG ключове
- върнато контролирано съобщение чрез `jsonError` при отчетена AI грешка
- добавен unit тест за симулиран `{ error: "AI грешка" }` отговор

## Тестване
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a873b26210832692fce675c000aefa