### PR TITLE
Улавяне на AI грешки чрез оператор "in"

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -559,7 +559,7 @@ async function handleAnalysisRequest(request, env) {
         const cleaned = extractJsonArray(keysResponse) || keysResponse;
         try {
             ragKeys = JSON.parse(cleaned);
-            if (ragKeys && typeof ragKeys === 'object' && Object.hasOwn(ragKeys, 'error')) {
+            if (ragKeys && typeof ragKeys === 'object' && 'error' in ragKeys) {
                 const msg = ragKeys.error;
                 log('AI върна грешка:', msg);
                 console.info('AI върна грешка:', msg);

--- a/worker.test.js
+++ b/worker.test.js
@@ -333,6 +333,39 @@ test('handleAnalysisRequest връща грешка при отговор { erro
   globalThis.fetch = originalFetch;
 });
 
+test('handleAnalysisRequest улавя грешка чрез наследено поле', async () => {
+  const buf = Buffer.alloc(10, 0);
+  const form = new FormData();
+  form.append('left-eye', new File([buf], 'l.jpg', { type: 'image/jpeg' }));
+  form.append('right-eye', new File([buf], 'r.jpg', { type: 'image/jpeg' }));
+
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () =>
+    new Response(
+      JSON.stringify({ choices: [{ message: { content: JSON.stringify({ error: 'AI грешка' }) } }] }),
+      { status: 200 }
+    );
+
+  const originalParse = JSON.parse;
+  JSON.parse = (str) => {
+    if (str === JSON.stringify({ error: 'AI грешка' })) {
+      return Object.create({ error: 'AI грешка' });
+    }
+    return originalParse(str);
+  };
+
+  const req = new Request('https://example.com/analyze', { method: 'POST', body: form });
+  const env = { AI_PROVIDER: 'openai', openai_api_key: 'k' };
+  const res = await worker.fetch(req, env);
+
+  JSON.parse = originalParse;
+
+  assert.equal(res.status, 400);
+  assert.deepEqual(await res.json(), { error: 'AI грешка' });
+
+  globalThis.fetch = originalFetch;
+});
+
 test('/admin/keys връща списък с ключове', async () => {
   const req = new Request('https://example.com/admin/keys');
   const env = {


### PR DESCRIPTION
## Резюме
- обработване на `{ error: ... }` отговори чрез проверка `'error' in ragKeys`
- добавен тест, който симулира наследено `error` поле и проверява `jsonError`

## Тестване
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1aa16779083268e67ea778f978101