### PR TITLE
feat: return rag_keys object schema

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -718,10 +718,17 @@ async function callOpenAIAPI(model, prompt, options, leftEye, rightEye, env, exp
             json_schema: {
                 name: "rag_keys",
                 schema: {
-                    type: "array",
-                    items: { type: "string" },
-                    minItems: 1,
-                    additionalItems: false
+                    type: "object",
+                    properties: {
+                        rag_keys: {
+                            type: "array",
+                            items: { type: "string" },
+                            minItems: 1,
+                            additionalItems: false
+                        }
+                    },
+                    required: ["rag_keys"],
+                    additionalProperties: false
                 }
             }
         };

--- a/worker.test.js
+++ b/worker.test.js
@@ -161,7 +161,7 @@ test('Изборът Gemini/gemini-1.5-flash се подава към API', asyn
   globalThis.fetch = originalFetch;
 });
 
-test('callOpenAIAPI изпраща json_schema и връща масив при expectJson=true', async () => {
+test('callOpenAIAPI изпраща json_schema и връща обект при expectJson=true', async () => {
   const env = { openai_api_key: 'key' };
   const originalFetch = globalThis.fetch;
   globalThis.fetch = async (url, options) => {
@@ -171,15 +171,22 @@ test('callOpenAIAPI изпраща json_schema и връща масив при e
       json_schema: {
         name: 'rag_keys',
         schema: {
-          type: 'array',
-          items: { type: 'string' },
-          minItems: 1,
-          additionalItems: false
+          type: 'object',
+          properties: {
+            rag_keys: {
+              type: 'array',
+              items: { type: 'string' },
+              minItems: 1,
+              additionalItems: false
+            }
+          },
+          required: ['rag_keys'],
+          additionalProperties: false
         }
       }
     });
     return new Response(
-      JSON.stringify({ choices: [{ message: { content: '["x","y"]' } }] }),
+      JSON.stringify({ choices: [{ message: { content: '{"rag_keys":["x","y"]}' } }] }),
       { status: 200 }
     );
   };
@@ -192,7 +199,7 @@ test('callOpenAIAPI изпраща json_schema и връща масив при e
     env,
     true
   );
-  assert.deepEqual(JSON.parse(result), ['x', 'y']);
+  assert.deepEqual(JSON.parse(result), { rag_keys: ['x', 'y'] });
   globalThis.fetch = originalFetch;
 });
 


### PR DESCRIPTION
## Summary
- wrap rag_keys in object schema when calling OpenAI
- adjust callOpenAIAPI test to expect object response

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1ddef7c488326b80c5a404c59da1d