### PR TITLE
Добавена поддръжка за динамични JSON схеми

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -460,6 +460,36 @@ async function adminDelete(env, request, key) {
 
 // --- ОРКЕСТРАТОР НА АНАЛИЗА ---
 
+// JSON схеми за форматиране на отговорите
+const RAG_KEYS_JSON_SCHEMA = {
+    name: 'rag_keys',
+    schema: {
+        type: 'object',
+        properties: {
+            rag_keys: {
+                type: 'array',
+                items: { type: 'string' },
+                minItems: 1,
+                additionalItems: false
+            }
+        },
+        required: ['rag_keys'],
+        additionalProperties: false
+    }
+};
+
+const ANALYSIS_JSON_SCHEMA = {
+    name: 'analysis',
+    schema: {
+        type: 'object',
+        properties: {
+            holistic_analysis: { type: 'string' }
+        },
+        required: ['holistic_analysis'],
+        additionalProperties: true
+    }
+};
+
 // Извлича първия JSON масив от низ, напр.: text -> "[\"a\",\"b\"]"
 function extractJsonArray(text = "") {
     let depth = 0;
@@ -553,7 +583,15 @@ async function handleAnalysisRequest(request, env) {
 
         log("Стъпка 1: Изпращане на заявка за идентификация на знаци...");
         const identificationApiCaller = provider === "gemini" ? callGeminiAPI : callOpenAIAPI;
-        const keysResponse = await identificationApiCaller(model, IDENTIFICATION_PROMPT, {}, leftEyeImage, rightEyeImage, env, true);
+        const keysResponse = await identificationApiCaller(
+            model,
+            IDENTIFICATION_PROMPT,
+            { jsonSchema: RAG_KEYS_JSON_SCHEMA },
+            leftEyeImage,
+            rightEyeImage,
+            env,
+            true
+        );
         
         let ragKeys;
         const cleaned = extractJsonArray(keysResponse) || keysResponse;
@@ -604,7 +642,15 @@ async function handleAnalysisRequest(request, env) {
 
         const synthesisApiCaller = provider === "gemini" ? callGeminiAPI : callOpenAIAPI;
         const rolePrompt = await getRolePrompt(env);
-        const finalAnalysis = await synthesisApiCaller(model, synthesisPrompt, { systemPrompt: rolePrompt }, leftEyeImage, rightEyeImage, env, true);
+        const finalAnalysis = await synthesisApiCaller(
+            model,
+            synthesisPrompt,
+            { systemPrompt: rolePrompt, jsonSchema: ANALYSIS_JSON_SCHEMA },
+            leftEyeImage,
+            rightEyeImage,
+            env,
+            true
+        );
         log("Финален анализ е генериран успешно.");
 
         let parsedAnalysis;
@@ -690,7 +736,7 @@ async function callGeminiAPI(model, prompt, options, leftEye, rightEye, env, exp
     return responseData.candidates[0].content.parts[0].text;
 }
 
-async function callOpenAIAPI(model, prompt, options, leftEye, rightEye, env, expectJson = true) {
+async function callOpenAIAPI(model, prompt, options = {}, leftEye, rightEye, env, expectJson = true) {
     const apiKey = env.openai_api_key || env.OPENAI_API_KEY;
     if (!apiKey) throw new Error("API ключът за OpenAI не е конфигуриран.");
     const url = "https://api.openai.com/v1/chat/completions";
@@ -713,24 +759,12 @@ async function callOpenAIAPI(model, prompt, options, leftEye, rightEye, env, exp
 
     const requestBody = { model, messages };
     if (expectJson) {
+        if (!options.jsonSchema) {
+            throw new Error('jsonSchema е задължителна при expectJson=true');
+        }
         requestBody.response_format = {
-            type: "json_schema",
-            json_schema: {
-                name: "rag_keys",
-                schema: {
-                    type: "object",
-                    properties: {
-                        rag_keys: {
-                            type: "array",
-                            items: { type: "string" },
-                            minItems: 1,
-                            additionalItems: false
-                        }
-                    },
-                    required: ["rag_keys"],
-                    additionalProperties: false
-                }
-            }
+            type: 'json_schema',
+            json_schema: options.jsonSchema
         };
     }
     if (options.max_tokens) {
@@ -862,7 +896,15 @@ export async function generateSummary(signs, ragRecords, env = {}, rolePrompt) {
 
     const systemPrompt = rolePrompt || await getRolePrompt(env);
     const apiCaller = provider === 'gemini' ? callGeminiAPI : callOpenAIAPI;
-    const aiResponse = await apiCaller(model, prompt, { systemPrompt }, null, null, env, true);
+    const aiResponse = await apiCaller(
+        model,
+        prompt,
+        { systemPrompt, jsonSchema: ANALYSIS_JSON_SCHEMA },
+        null,
+        null,
+        env,
+        true
+    );
     const parsed = JSON.parse(aiResponse);
 
     const actions = ragRecords && ragRecords.support
@@ -975,4 +1017,4 @@ function jsonError(message, status = 400, request, env, extraHeaders = {}) {
     });
 }
 
-export { validateImageSize, fileToBase64, corsHeaders, callOpenAIAPI, callGeminiAPI, fetchExternalInfo };
+export { validateImageSize, fileToBase64, corsHeaders, callOpenAIAPI, callGeminiAPI, fetchExternalInfo, RAG_KEYS_JSON_SCHEMA, ANALYSIS_JSON_SCHEMA };

--- a/worker.test.js
+++ b/worker.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import worker, { validateImageSize, fileToBase64, corsHeaders, getAIProvider, getAIModel, callOpenAIAPI, callGeminiAPI, fetchRagData, fetchExternalInfo, generateSummary } from './worker.js';
+import worker, { validateImageSize, fileToBase64, corsHeaders, getAIProvider, getAIModel, callOpenAIAPI, callGeminiAPI, fetchRagData, fetchExternalInfo, generateSummary, RAG_KEYS_JSON_SCHEMA } from './worker.js';
 import { KV_DATA } from './kv-data.js';
 
 test('Worker не използва браузърни API', () => {
@@ -168,22 +168,7 @@ test('callOpenAIAPI изпраща json_schema и връща обект при e
     const body = JSON.parse(options.body);
     assert.deepEqual(body.response_format, {
       type: 'json_schema',
-      json_schema: {
-        name: 'rag_keys',
-        schema: {
-          type: 'object',
-          properties: {
-            rag_keys: {
-              type: 'array',
-              items: { type: 'string' },
-              minItems: 1,
-              additionalItems: false
-            }
-          },
-          required: ['rag_keys'],
-          additionalProperties: false
-        }
-      }
+      json_schema: RAG_KEYS_JSON_SCHEMA
     });
     return new Response(
       JSON.stringify({ choices: [{ message: { content: '{"rag_keys":["x","y"]}' } }] }),
@@ -193,7 +178,7 @@ test('callOpenAIAPI изпраща json_schema и връща обект при e
   const result = await callOpenAIAPI(
     'gpt-4o',
     'p',
-    {},
+    { jsonSchema: RAG_KEYS_JSON_SCHEMA },
     { data: 'a', type: 'image/png' },
     { data: 'b', type: 'image/png' },
     env,
@@ -574,8 +559,12 @@ test('handleAnalysisRequest преобразува алиасите към ка�
     JSON.stringify({ choices: [{ message: { content: JSON.stringify({ holistic_analysis: 'ok' }) } }] })
   ];
   let idx = 0;
+  const bodies = [];
   const originalFetch = globalThis.fetch;
-  globalThis.fetch = async () => new Response(responses[idx++], { status: 200 });
+  globalThis.fetch = async (_url, init) => {
+    bodies.push(JSON.parse(init.body));
+    return new Response(responses[idx++], { status: 200 });
+  };
 
   const res = await worker.fetch(req, env);
 
@@ -584,6 +573,8 @@ test('handleAnalysisRequest преобразува алиасите към ка�
 
   assert.equal(res.status, 200);
   assert.deepEqual(fetched, ['SIGN_IRIS_RADII_SOLARIS']);
+  assert.equal(bodies[0].response_format.json_schema.name, 'rag_keys');
+  assert.equal(bodies[1].response_format.json_schema.name, 'analysis');
 });
 
 test('fetchExternalInfo връща null без предупреждение при липсващи ключове', async () => {
@@ -600,14 +591,19 @@ test('fetchExternalInfo връща null без предупреждение пр
 
 test('generateSummary добавя actions от ragRecords.support', async () => {
   const env = { AI_PROVIDER: 'openai', AI_MODEL: 'gpt-4o-mini', openai_api_key: 'key' };
+  const bodies = [];
   const originalFetch = globalThis.fetch;
-  globalThis.fetch = async () => new Response(
-    JSON.stringify({ choices: [{ message: { content: JSON.stringify({ summary: 's', holistic_analysis: 'h' }) } }] }),
-    { status: 200 }
-  );
+  globalThis.fetch = async (_url, init) => {
+    bodies.push(JSON.parse(init.body));
+    return new Response(
+      JSON.stringify({ choices: [{ message: { content: JSON.stringify({ summary: 's', holistic_analysis: 'h' }) } }] }),
+      { status: 200 }
+    );
+  };
   const res = await generateSummary(['SIGN_A'], { support: ['Drink water'] }, env);
   globalThis.fetch = originalFetch;
   assert.deepEqual(res.actions, ['Drink water']);
+  assert.equal(bodies[0].response_format.json_schema.name, 'analysis');
 });
 
 test('handleAnalysisRequest пропуска извличането на публични източници при липса на Google ключове', async () => {


### PR DESCRIPTION
## Обобщение
- Позволих `callOpenAIAPI` да приема външна `jsonSchema` и да я използва при `response_format`
- Подадох подходящи схеми в `handleAnalysisRequest` и `generateSummary` за `rag_keys` и `holistic_analysis`
- Разширих тестовете, които потвърждават изпращането на верните схеми към OpenAI API

## Тестване
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1e0d9e0d48326807457a25dc37f74