### PR TITLE
feat: enable dynamic analysis json schema

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -165,6 +165,47 @@ export async function getAIModel(env = {}) {
     return provider === 'openai' ? 'gpt-4o' : 'gemini-1.5-pro';
 }
 
+// Гарантира присъствието на поле "holistic_analysis" в схемата
+function ensureHolisticSchema(schema = {}) {
+    if (!schema.properties) schema.properties = {};
+    if (!schema.properties.holistic_analysis) {
+        schema.properties.holistic_analysis = { type: 'string' };
+    }
+    if (!Array.isArray(schema.required)) schema.required = [];
+    if (!schema.required.includes('holistic_analysis')) {
+        schema.required.push('holistic_analysis');
+    }
+    return schema;
+}
+
+// Извлича динамична схема за финален анализ от ENV или KV с кеширане
+async function getAnalysisJsonSchema(env = {}) {
+    if (getAnalysisJsonSchema.cache) {
+        return getAnalysisJsonSchema.cache;
+    }
+    let schema;
+    if (env.ANALYSIS_JSON_SCHEMA) {
+        try {
+            schema = typeof env.ANALYSIS_JSON_SCHEMA === 'string'
+                ? JSON.parse(env.ANALYSIS_JSON_SCHEMA)
+                : env.ANALYSIS_JSON_SCHEMA;
+        } catch (e) {
+            console.warn('Невалидна ANALYSIS_JSON_SCHEMA в ENV:', e);
+        }
+    } else if (env.iris_rag_kv) {
+        try {
+            schema = await env.iris_rag_kv.get('ANALYSIS_JSON_SCHEMA', 'json');
+        } catch (e) {
+            console.warn('Неуспешно извличане на ANALYSIS_JSON_SCHEMA от KV:', e);
+        }
+    }
+    const result = (!schema || typeof schema !== 'object')
+        ? ANALYSIS_JSON_SCHEMA
+        : { name: 'analysis', schema: ensureHolisticSchema(schema) };
+    getAnalysisJsonSchema.cache = result;
+    return result;
+}
+
 // --- ОТЛОГВАНЕ ---
 function debugLog(env = {}, ...args) {
     if (env.DEBUG === "true") {
@@ -650,10 +691,11 @@ async function handleAnalysisRequest(request, env) {
 
         const synthesisApiCaller = provider === "gemini" ? callGeminiAPI : callOpenAIAPI;
         const rolePrompt = await getRolePrompt(env);
+        const analysisSchema = await getAnalysisJsonSchema(env);
         const finalAnalysis = await synthesisApiCaller(
             model,
             synthesisPrompt,
-            { systemPrompt: rolePrompt, jsonSchema: ANALYSIS_JSON_SCHEMA },
+            { systemPrompt: rolePrompt, jsonSchema: analysisSchema },
             leftEyeImage,
             rightEyeImage,
             env,
@@ -894,7 +936,7 @@ export async function fetchRagData(keys, env) {
 }
 
 // --- СИНТЕЗ НА АНАЛИЗА ---
-export async function generateSummary(signs, ragRecords, env = {}, rolePrompt) {
+export async function generateSummary(signs, ragRecords, env = {}, rolePrompt, analysisSchema) {
     const provider = await getAIProvider(env);
     const model = await getAIModel(env);
 
@@ -903,11 +945,14 @@ export async function generateSummary(signs, ragRecords, env = {}, rolePrompt) {
         .replace('{{RAG_DATA}}', JSON.stringify(ragRecords, null, 2));
 
     const systemPrompt = rolePrompt || await getRolePrompt(env);
+    const schemaWrapper = analysisSchema
+        ? { name: analysisSchema.name || 'analysis', schema: ensureHolisticSchema(analysisSchema.schema || {}) }
+        : await getAnalysisJsonSchema(env);
     const apiCaller = provider === 'gemini' ? callGeminiAPI : callOpenAIAPI;
     const aiResponse = await apiCaller(
         model,
         prompt,
-        { systemPrompt, jsonSchema: ANALYSIS_JSON_SCHEMA },
+        { systemPrompt, jsonSchema: schemaWrapper },
         null,
         null,
         env,
@@ -1025,4 +1070,4 @@ function jsonError(message, status = 400, request, env, extraHeaders = {}) {
     });
 }
 
-export { validateImageSize, fileToBase64, corsHeaders, callOpenAIAPI, callGeminiAPI, fetchExternalInfo, RAG_KEYS_JSON_SCHEMA, ANALYSIS_JSON_SCHEMA };
+export { validateImageSize, fileToBase64, corsHeaders, callOpenAIAPI, callGeminiAPI, fetchExternalInfo, RAG_KEYS_JSON_SCHEMA, ANALYSIS_JSON_SCHEMA, getAnalysisJsonSchema };

--- a/worker.test.js
+++ b/worker.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import worker, { validateImageSize, fileToBase64, corsHeaders, getAIProvider, getAIModel, callOpenAIAPI, callGeminiAPI, fetchRagData, fetchExternalInfo, generateSummary, RAG_KEYS_JSON_SCHEMA } from './worker.js';
+import worker, { validateImageSize, fileToBase64, corsHeaders, getAIProvider, getAIModel, callOpenAIAPI, callGeminiAPI, fetchRagData, fetchExternalInfo, generateSummary, RAG_KEYS_JSON_SCHEMA, getAnalysisJsonSchema } from './worker.js';
 import { KV_DATA } from './kv-data.js';
 
 test('Worker не използва браузърни API', () => {
@@ -572,7 +572,7 @@ test('handleAnalysisRequest преобразува алиасите към ка�
   delete globalThis.caches;
 
   assert.equal(res.status, 200);
-  assert.deepEqual(fetched, ['SIGN_IRIS_RADII_SOLARIS']);
+  assert.deepEqual(fetched, ['SIGN_IRIS_RADII_SOLARIS', 'ANALYSIS_JSON_SCHEMA']);
   assert.equal(bodies[0].response_format.json_schema.name, 'rag_keys');
   assert.equal(bodies[1].response_format.json_schema.name, 'analysis');
 });
@@ -604,6 +604,38 @@ test('generateSummary добавя actions от ragRecords.support', async () =>
   globalThis.fetch = originalFetch;
   assert.deepEqual(res.actions, ['Drink water']);
   assert.equal(bodies[0].response_format.json_schema.name, 'analysis');
+});
+
+test('generateSummary приема custom json_schema', async () => {
+  const env = { AI_PROVIDER: 'openai', AI_MODEL: 'gpt-4o-mini', openai_api_key: 'key' };
+  const bodies = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (_url, init) => {
+    bodies.push(JSON.parse(init.body));
+    return new Response(
+      JSON.stringify({ choices: [{ message: { content: JSON.stringify({ holistic_analysis: 'h', extra: 'e' }) } }] }),
+      { status: 200 }
+    );
+  };
+  const customSchema = {
+    name: 'custom',
+    schema: { type: 'object', properties: { extra: { type: 'string' } }, required: ['extra'] }
+  };
+  await generateSummary(['SIGN_A'], {}, env, undefined, customSchema);
+  globalThis.fetch = originalFetch;
+  const sent = bodies[0].response_format.json_schema;
+  assert.equal(sent.name, 'custom');
+  assert.deepEqual(sent.schema.required.sort(), ['extra', 'holistic_analysis']);
+});
+
+test('getAnalysisJsonSchema кешира резултата от KV', async () => {
+  getAnalysisJsonSchema.cache = undefined;
+  let calls = 0;
+  const env = { iris_rag_kv: { get: async () => { calls++; return {}; } } };
+  await getAnalysisJsonSchema(env);
+  await getAnalysisJsonSchema(env);
+  assert.equal(calls, 1);
+  getAnalysisJsonSchema.cache = undefined;
 });
 
 test('handleAnalysisRequest пропуска извличането на публични източници при липса на Google ключове', async () => {


### PR DESCRIPTION
## Summary
- allow dynamic retrieval of analysis json schema with mandatory `holistic_analysis`
- support custom schema overrides in `generateSummary`
- test custom schema handling
- cache retrieved analysis schema to reduce repeated KV reads

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2564b86ac83269f979c194aec8639