### PR TITLE
feat: add R2 image upload and URL support

### DIFF
--- a/worker.test.js
+++ b/worker.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import worker, { validateImageSize, fileToBase64, corsHeaders, getAIProvider, getAIModel, callOpenAIAPI, callGeminiAPI, fetchRagData, fetchExternalInfo, generateSummary, RAG_KEYS_JSON_SCHEMA, getAnalysisJsonSchema } from './worker.js';
+import worker, { validateImageSize, fileToBase64, uploadImageAndGetUrl, corsHeaders, getAIProvider, getAIModel, callOpenAIAPI, callGeminiAPI, fetchRagData, fetchExternalInfo, generateSummary, RAG_KEYS_JSON_SCHEMA, getAnalysisJsonSchema } from './worker.js';
 import { KV_DATA } from './kv-data.js';
 
 test('Worker не използва браузърни API', () => {
@@ -36,6 +36,13 @@ test('fileToBase64 обработва файл по-голям от 8KB', async 
   const result = await fileToBase64(file);
   assert.equal(result.data, expected);
   assert.equal(result.type, 'image/jpeg');
+});
+
+test('uploadImageAndGetUrl връща null при липсващо bucket', async () => {
+  const buffer = Buffer.alloc(10, 0);
+  const file = new File([buffer], 'tmp.jpg', { type: 'image/jpeg' });
+  const url = await uploadImageAndGetUrl(file, {});
+  assert.equal(url, null);
 });
 
 test('corsHeaders поддържа wildcard "*"', () => {


### PR DESCRIPTION
## Summary
- allow OpenAI and Gemini calls to accept `leftEyeUrl` / `rightEyeUrl`
- add `uploadImageAndGetUrl` helper for R2/S3 uploads with temporary URLs
- fall back to existing base64 flow when no URL is available
- cover upload helper with unit test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2f86478b08326bdf802e5b263c4f2