### PR TITLE
Добавяне на eye JSON маркери към изображенията

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -117,6 +117,7 @@ const DEFAULT_ROLE_PROMPT = `
 3. Използвай единствено информацията от входните данни и RAG.
 4. Ако липсва информация, заяви го изрично и не прави предположения. Ако липсва информация, опиши какви допълнителни данни са нужни.
 5. Не поставяй медицински диагнози и не предписвай лечение; формулирай анализите като образователни насоки.
+6. Всяко входно изображение е последвано от текстов JSON с поле "eye" ("left" или "right"), което указва кое око показва.
 
 # ВАЖЕН ДИСКЛЕЙМЪР
 **Винаги завършвай всеки анализ с този РАЗШИРЕН текст:**
@@ -755,17 +756,17 @@ async function callGeminiAPI(model, prompt, options, leftEye, rightEye, env, exp
     const parts = [{ text: prompt }];
     if (leftEyeUrl) {
         parts.push({ file_uri: leftEyeUrl });
-        parts.push({ text: "\n(Снимка на ЛЯВО око)" });
+        parts.push({ text: '{"eye":"left"}' });
     } else if (leftEye) {
         parts.push({ inline_data: { mime_type: leftEye.type, data: leftEye.data } });
-        parts.push({ text: "\n(Снимка на ЛЯВО око)" });
+        parts.push({ text: '{"eye":"left"}' });
     }
     if (rightEyeUrl) {
         parts.push({ file_uri: rightEyeUrl });
-        parts.push({ text: "\n(Снимка на ДЯСНО око)" });
+        parts.push({ text: '{"eye":"right"}' });
     } else if (rightEye) {
         parts.push({ inline_data: { mime_type: rightEye.type, data: rightEye.data } });
-        parts.push({ text: "\n(Снимка на ДЯСНО око)" });
+        parts.push({ text: '{"eye":"right"}' });
     }
 
     const requestBody = {
@@ -818,17 +819,17 @@ async function callOpenAIAPI(model, prompt, options = {}, leftEye, rightEye, env
     const content = [{ type: "text", text: prompt }];
     if (leftEyeUrl) {
         content.push({ type: "image_url", image_url: { url: leftEyeUrl } });
-        content.push({ type: "text", text: "\n(Снимка на ЛЯВО око)" });
+        content.push({ type: 'text', text: '{"eye":"left"}' });
     } else if (leftEye) {
         content.push({ type: "image_url", image_url: { url: `data:${leftEye.type};base64,${leftEye.data}` }});
-        content.push({ type: "text", text: "\n(Снимка на ЛЯВО око)" });
+        content.push({ type: 'text', text: '{"eye":"left"}' });
     }
     if (rightEyeUrl) {
         content.push({ type: "image_url", image_url: { url: rightEyeUrl } });
-        content.push({ type: "text", text: "\n(Снимка на ДЯСНО око)" });
+        content.push({ type: 'text', text: '{"eye":"right"}' });
     } else if (rightEye) {
         content.push({ type: "image_url", image_url: { url: `data:${rightEye.type};base64,${rightEye.data}` }});
-        content.push({ type: "text", text: "\n(Снимка на ДЯСНО око)" });
+        content.push({ type: 'text', text: '{"eye":"right"}' });
     }
     messages.push({ role: "user", content });
 

--- a/worker.test.js
+++ b/worker.test.js
@@ -166,6 +166,9 @@ test('Изборът OpenAI/gpt-4o-mini се подава към API', async () 
     const body = JSON.parse(options.body);
     assert.equal(body.model, 'gpt-4o-mini');
     assert.equal(body.messages[0].content[1].image_url.url, 'data:image/png;base64,a');
+    assert.equal(body.messages[0].content[2].text, '{"eye":"left"}');
+    assert.equal(body.messages[0].content[3].image_url.url, 'data:image/png;base64,b');
+    assert.equal(body.messages[0].content[4].text, '{"eye":"right"}');
     return new Response(JSON.stringify({ choices: [{ message: { content: 'ok' } }] }), { status: 200 });
   };
   await callOpenAIAPI('gpt-4o-mini', 'p', {}, { data: 'a', type: 'image/png' }, { data: 'b', type: 'image/png' }, env, false);
@@ -180,6 +183,9 @@ test('Изборът Gemini/gemini-1.5-flash се подава към API', asyn
     const body = JSON.parse(options.body);
     assert.equal(body.contents[0].parts[1].inline_data.mime_type, 'image/png');
     assert.equal(body.contents[0].parts[1].inline_data.data, 'a');
+    assert.equal(body.contents[0].parts[2].text, '{"eye":"left"}');
+    assert.equal(body.contents[0].parts[3].inline_data.data, 'b');
+    assert.equal(body.contents[0].parts[4].text, '{"eye":"right"}');
     return new Response(JSON.stringify({ candidates: [{ content: { parts: [{ text: 'ok' }] } }] }), { status: 200 });
   };
   await callGeminiAPI('gemini-1.5-flash', 'p', {}, { data: 'a', type: 'image/png' }, { data: 'b', type: 'image/png' }, env, false);


### PR DESCRIPTION
## Обобщение
- Заменени текстовите бележки за изображенията с JSON маркери `{ "eye": "left|right" }` в `callOpenAIAPI` и `callGeminiAPI`.
- Системният промпт вече описва, че всяко изображение е придружено от поле `eye`.
- Тестовете актуализирани да проверяват новия формат на заявките.

## Тестване
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3048f44408326be86539720e32513