### PR TITLE
feat: add image format support

### DIFF
--- a/worker.test.js
+++ b/worker.test.js
@@ -38,6 +38,24 @@ test('fileToBase64 обработва файл по-голям от 8KB', async 
   assert.equal(result.type, 'image/jpeg');
 });
 
+test('fileToBase64 запазва MIME за PNG', async () => {
+  const buffer = Buffer.alloc(10, 0);
+  const file = new File([buffer], 'img.png', { type: 'image/png' });
+  const expected = buffer.toString('base64');
+  const result = await fileToBase64(file);
+  assert.equal(result.data, expected);
+  assert.equal(result.type, 'image/png');
+});
+
+test('fileToBase64 запазва MIME за WebP', async () => {
+  const buffer = Buffer.alloc(10, 0);
+  const file = new File([buffer], 'img.webp', { type: 'image/webp' });
+  const expected = buffer.toString('base64');
+  const result = await fileToBase64(file);
+  assert.equal(result.data, expected);
+  assert.equal(result.type, 'image/webp');
+});
+
 test('uploadImageAndGetUrl връща null при липсващо bucket', async () => {
   const buffer = Buffer.alloc(10, 0);
   const file = new File([buffer], 'tmp.jpg', { type: 'image/jpeg' });


### PR DESCRIPTION
## Summary
- allow preprocessImage to output JPEG, PNG or WebP via canvas `convertToBlob`
- keep MIME type from preprocessing when converting images to base64
- cover PNG and WebP inputs in fileToBase64 tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b30b95aa388326aeb3241ec6dce42f