### PR TITLE
Добавен разширен ANALYSIS_JSON_SCHEMA и тестове

### DIFF
--- a/KV/ANALYSIS_JSON_SCHEMA
+++ b/KV/ANALYSIS_JSON_SCHEMA
@@ -1,0 +1,13 @@
+{
+  "name": "analysis",
+  "schema": {
+    "type": "object",
+    "properties": {
+      "summary": { "type": "string" },
+      "recommendations": { "type": "string" },
+      "holistic_analysis": { "type": "string" }
+    },
+    "required": ["summary", "recommendations", "holistic_analysis"],
+    "additionalProperties": true
+  }
+}


### PR DESCRIPTION
## Обобщение
- Разширен `ANALYSIS_JSON_SCHEMA` със задължителни ключове `summary`, `recommendations` и `holistic_analysis`.
- `getAnalysisJsonSchema` вече чете структурирани данни от ENV/KV и поддържа изчистване на кеша.
- Добавени тестове за новата схема и обновено покритие в `worker.test.js`.

## Тестване
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3178354b08326ac1cd7da5503e815