### PR TITLE
Use WebWorker types in worker.js

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -1,4 +1,3 @@
-/// <reference lib="dom" />
 /// <reference lib="webworker" />
 // --- ПРЕРАБОТКА НА ИЗОБРАЖЕНИЯ ---
 // Обработката на изображения вече се извършва клиентски.
@@ -1025,6 +1024,7 @@ function prepareImages(leftEye, rightEye, leftEyeUrl, rightEyeUrl) {
 }
 
 function buildGeminiParts(prompt, leftEye, rightEye, leftEyeUrl, rightEyeUrl) {
+    /** @type {Array<{text:string}|{file_uri:string}|{inline_data:{mime_type:string,data:string}}>} */
     const parts = [{ text: prompt }];
     for (const img of prepareImages(leftEye, rightEye, leftEyeUrl, rightEyeUrl)) {
         const meta = { eye: img.eye };


### PR DESCRIPTION
## Summary
- drop DOM lib reference in worker.js
- type Gemini content parts with a union for text, file and inline data

## Testing
- `npx tsc --noEmit --project jsconfig.json`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b342a5a84c8326a6cf23e7f36a160e