### PR TITLE
Добави проверка за наличност на KV записи

### DIFF
--- a/.github/workflows/kv-sync.yml
+++ b/.github/workflows/kv-sync.yml
@@ -17,6 +17,7 @@ jobs:
           node-version: '20'
       - run: npm ci
       - run: npm run test:kv
+      - run: npm run validate-kv
       - run: node upload-kv.js
         env:
           CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "node worker.test.js",
     "upload-kv": "node upload-kv.js",
     "test:kv": "node scripts/validate-kv.js",
+    "validate-kv": "node scripts/validate-kv-summary.js",
     "build:kv": "node scripts/generate-kv-data.js",
     "sync:kv": "node scripts/sync-kv.js",
     "watch:kv": "node scripts/sync-kv.js",

--- a/scripts/validate-kv-summary.js
+++ b/scripts/validate-kv-summary.js
@@ -1,0 +1,39 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const SUMMARY_FILE = path.resolve('rag-kv-summary.json');
+const KV_DIR = path.resolve('KV');
+
+async function main() {
+  const raw = await fs.readFile(SUMMARY_FILE, 'utf8');
+  const summary = JSON.parse(raw);
+  const keys = Object.keys(summary).filter(k => /^[A-Z0-9_]+$/.test(k));
+  const missing = [];
+
+  for (const key of keys) {
+    const candidates = [path.join(KV_DIR, key), path.join(KV_DIR, `${key}.json`)];
+    let exists = false;
+    for (const file of candidates) {
+      try {
+        await fs.access(file);
+        exists = true;
+        break;
+      } catch {}
+    }
+    if (!exists) {
+      missing.push(key);
+    }
+  }
+
+  if (missing.length) {
+    console.error(`Липсващи KV записи: ${missing.join(', ')}`);
+    process.exit(1);
+  }
+
+  console.log('Всички записи от rag-kv-summary.json са налични в KV/');
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- добавен скрипт за валидиране на ключовете в `KV/` спрямо `rag-kv-summary.json`
- добавена `npm run validate-kv` команда за стартиране на проверката
- интегрирана проверка в `KV Sync` GitHub workflow

## Testing
- `npm test`
- `npm run validate-kv`


------
https://chatgpt.com/codex/tasks/task_e_68b34861efcc832690338a58106093ac