### PR TITLE
Валидация на ключовете в KV синхронизацията

### DIFF
--- a/kv-sync.js
+++ b/kv-sync.js
@@ -1,6 +1,10 @@
 export function validateKv(data) {
+  const keyRegex = /^[A-Z0-9_]+$/;
   const entries = [];
   for (const [key, value] of Object.entries(data)) {
+    if (!keyRegex.test(key)) {
+      throw new Error(`Невалиден ключ: ${key}`);
+    }
     try {
       JSON.parse(value);
     } catch (err) {

--- a/kv-sync.test.js
+++ b/kv-sync.test.js
@@ -1,0 +1,14 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { validateKv } from './kv-sync.js';
+
+test('validateKv приема валиден ключ', () => {
+  const data = { 'VALID_KEY': '{"a":1}' };
+  const entries = validateKv(data);
+  assert.deepEqual(entries, [{ key: 'VALID_KEY', value: '{"a":1}' }]);
+});
+
+test('validateKv хвърля грешка при невалиден ключ', () => {
+  const data = { 'invalid-key': '{"a":1}' };
+  assert.throws(() => validateKv(data));
+});


### PR DESCRIPTION
## Резюме
- добавена валидация на ключовете с `^[A-Z0-9_]+$`
- тестове за валидни и невалидни ключове

## Тестване
- `node kv-sync.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b34c42226c83269c43f5254f0a9261