### PR TITLE
Премахване на празни KV стойности при синхронизация

### DIFF
--- a/kv-sync.test.js
+++ b/kv-sync.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { validateKv } from './kv-sync.js';
+import { validateKv, syncKv } from './kv-sync.js';
 
 test('validateKv приема валиден ключ', () => {
   const data = { 'VALID_KEY': '{"a":1}' };
@@ -11,4 +11,46 @@ test('validateKv приема валиден ключ', () => {
 test('validateKv хвърля грешка при невалиден ключ', () => {
   const data = { 'invalid-key': '{"a":1}' };
   assert.throws(() => validateKv(data));
+});
+
+test('validateKv маркира празни стойности за изтриване', () => {
+  const data = { 'EMPTY': '""', 'EMPTY_OBJ': '{}' };
+  const entries = validateKv(data);
+  assert.deepEqual(entries, [
+    { key: 'EMPTY', delete: true },
+    { key: 'EMPTY_OBJ', delete: true }
+  ]);
+});
+
+test('syncKv изчиства празните ключове', async () => {
+  const originalFetch = global.fetch;
+  let uploaded;
+  global.fetch = async (url, opts) => {
+    if (url.includes('/keys')) {
+      return {
+        ok: true,
+        json: async () => ({
+          result: [{ name: 'DROP1' }, { name: 'EXTRA' }],
+          result_info: { list_complete: true }
+        })
+      };
+    }
+    uploaded = JSON.parse(opts.body);
+    return { ok: true, text: async () => '' };
+  };
+
+  const entries = validateKv({ KEEP: '"ok"', DROP1: '""', DROP2: '{}' });
+  const res = await syncKv(entries, { accountId: 'a', namespaceId: 'n', apiToken: 't' });
+
+  assert.deepEqual(uploaded, [
+    { key: 'KEEP', value: '"ok"' },
+    { key: 'DROP1', delete: true },
+    { key: 'DROP2', delete: true },
+    { key: 'EXTRA', delete: true }
+  ]);
+  assert.deepEqual(res.updated, ['KEEP']);
+  assert.deepEqual(res.deleted.sort(), ['DROP1', 'DROP2', 'EXTRA'].sort());
+  assert.deepEqual(res.groups, { KEEP: ['KEEP'] });
+
+  global.fetch = originalFetch;
 });


### PR DESCRIPTION
## Резюме
- Маркиране на празни стойности (`""` и `{}`) за изтриване при валидация.
- Синхронизиране на KV, което премахва празните записи и изтрива съществуващите ключове.
- Добавени тестове за валидация и изчистване на празни ключове.

## Тестване
- `node kv-sync.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b34d8d10948326b5eaf2e693bb765c