### PR TITLE
feat: RAG key validation

### DIFF
--- a/upload-kv.js
+++ b/upload-kv.js
@@ -2,6 +2,7 @@ import 'dotenv/config';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { validateKv, syncKv } from './kv-sync.js';
+import { validateRagKeys } from './validate-rag-keys.js';
 
 const ACCOUNT_ID = process.env.CF_ACCOUNT_ID;
 const NAMESPACE_ID = process.env.CF_KV_NAMESPACE_ID;
@@ -10,6 +11,7 @@ const KV_DIR = path.resolve('KV');
 const REQUIRED_SENTENCE = 'Ако липсва информация, опиши какви допълнителни данни са нужни.';
 
 async function main() {
+  validateRagKeys();
   if (!ACCOUNT_ID || !NAMESPACE_ID || !API_TOKEN) {
     console.error('Липсват променливи CF_ACCOUNT_ID, CF_KV_NAMESPACE_ID или CF_API_TOKEN.');
     process.exit(1);

--- a/validate-rag-keys.js
+++ b/validate-rag-keys.js
@@ -1,0 +1,34 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { KV_DATA } from './kv-data.js';
+
+function extractWorkerKeys() {
+  const workerPath = path.resolve('worker.js');
+  const src = fs.readFileSync(workerPath, 'utf8');
+  const match = src.match(/const RAG_KEY_ALIASES = \{([\s\S]*?)\};/);
+  const keys = new Set(['ROLE_PROMPT', 'AI_MODEL', 'AI_PROVIDER']);
+  if (match) {
+    const block = match[1];
+    const regex = /:\s*'([^']+)'/g;
+    let m;
+    while ((m = regex.exec(block)) !== null) {
+      keys.add(m[1]);
+    }
+  }
+  return Array.from(keys);
+}
+
+export function validateRagKeys() {
+  const kvKeys = Object.keys(KV_DATA);
+  const expected = extractWorkerKeys();
+  const missing = expected.filter(k => !kvKeys.includes(k));
+  if (missing.length) {
+    throw new Error(`Липсващи RAG ключове: ${missing.join(', ')}`);
+  }
+  return true;
+}
+
+if (import.meta.main) {
+  validateRagKeys();
+  console.log('Всички очаквани RAG ключове са налични.');
+}

--- a/worker.test.js
+++ b/worker.test.js
@@ -2,6 +2,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import worker, { validateImageSize, fileToBase64, uploadImageAndGetUrl, corsHeaders, getAIProvider, getAIModel, callOpenAIAPI, callGeminiAPI, fetchRagData, fetchExternalInfo, generateSummary, RAG_KEYS_JSON_SCHEMA, getAnalysisJsonSchema, resetAnalysisJsonSchemaCache } from './worker.js';
 import { KV_DATA } from './kv-data.js';
+import { validateRagKeys } from './validate-rag-keys.js';
 
 test('Worker не използва браузърни API', () => {
   assert.equal(typeof globalThis.window, 'undefined');
@@ -13,6 +14,10 @@ test('ROLE_PROMPT съдържа ключ missing_data', () => {
   const data = JSON.parse(KV_DATA.ROLE_PROMPT);
   assert.ok(Object.hasOwn(data, 'missing_data'));
   assert.equal(typeof data.missing_data, 'string');
+});
+
+test('kv-data съдържа очакваните RAG ключове', () => {
+  validateRagKeys();
 });
 
 test('validateImageSize връща грешка при твърде голям файл', async () => {


### PR DESCRIPTION
## Summary
- add script validating RAG keys against worker aliases
- run RAG key check in tests and KV upload script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3a7db23d48326a6b210619ffbc6b4