### PR TITLE
Оптимизация на compressImage

### DIFF
--- a/script.js
+++ b/script.js
@@ -121,6 +121,12 @@ document.addEventListener('DOMContentLoaded', function() {
         return new Promise((resolve, reject) => {
             const img = new Image();
             img.onload = async () => {
+                const withinBounds = img.width <= maxSize && img.height <= maxSize;
+                if (file.size < 2 * 1024 * 1024 && withinBounds) {
+                    URL.revokeObjectURL(img.src);
+                    return resolve(file);
+                }
+
                 const canvas = document.createElement('canvas');
                 const scale = Math.min(maxSize / img.width, maxSize / img.height, 1);
                 canvas.width = img.width * scale;


### PR DESCRIPTION
## Резюме
- Прескачане на компресията за файлове под 2MB и в допустимите размери
- Използване на canvas само когато изображението изисква оразмеряване или конвертиране

## Тестване
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b44bfb12108326988054ddd2e86f57