### PR TITLE
Handle null and whitespace KV values

### DIFF
--- a/kv-sync.js
+++ b/kv-sync.js
@@ -13,6 +13,8 @@ export function validateKv(data) {
     }
     if (
       parsed === "" ||
+      parsed === null ||
+      (typeof parsed === 'string' && parsed.trim() === '') ||
       (parsed && typeof parsed === 'object' && Object.keys(parsed).length === 0)
     ) {
       entries.push({ key, delete: true });


### PR DESCRIPTION
## Summary
- treat `null` and whitespace-only strings as deletions during KV validation
- expand KV sync tests to cover null and whitespace scenarios

## Testing
- `node --test kv-sync.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b45504dce483268f94020ea923e204