### PR TITLE
Итерация на всички KV ключове чрез API

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -441,8 +441,13 @@ async function adminSync(env, request) {
 
 async function adminKeys(env, request) {
     try {
-        const { keys } = await env.iris_rag_kv.list({ limit: 1000 });
-        return new Response(JSON.stringify({ keys: keys.map(k => k.name) }), {
+        const keys = await fetchExistingKeys({
+            accountId: env.CF_ACCOUNT_ID,
+            namespaceId: env.CF_KV_NAMESPACE_ID,
+            apiToken: env.CF_API_TOKEN
+        });
+        const unique = [...new Set(keys)];
+        return new Response(JSON.stringify({ keys: unique }), {
             headers: corsHeaders(request, env, { 'Content-Type': 'application/json' })
         });
     } catch (err) {

--- a/worker.test.js
+++ b/worker.test.js
@@ -435,11 +435,22 @@ test('handleAnalysisRequest улавя грешка чрез наследено 
 test('/admin/keys връща списък с ключове', async () => {
   const req = new Request('https://example.com/admin/keys');
   const env = {
-    iris_rag_kv: { list: async () => ({ keys: [] }) }
+    CF_ACCOUNT_ID: 'a',
+    CF_KV_NAMESPACE_ID: 'n',
+    CF_API_TOKEN: 't'
   };
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => new Response(
+    JSON.stringify({
+      result: [{ name: 'K1' }, { name: 'K1' }, { name: 'K2' }],
+      result_info: { list_complete: true }
+    }),
+    { status: 200 }
+  );
   const res = await worker.fetch(req, env);
+  globalThis.fetch = originalFetch;
   assert.equal(res.status, 200);
-  assert.deepEqual(await res.json(), { keys: [] });
+  assert.deepEqual(await res.json(), { keys: ['K1', 'K2'] });
 });
 
 


### PR DESCRIPTION
## Резюме
- Извличане на реални KV ключове през Cloudflare API с курсор
- Връщане на уникален списък в admin/keys
- Актуализиран тест за новия начин на извличане

## Тестване
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b45666b1cc83269e29402ba867eff9