### PR TITLE
Добавена админ функция за почистване на празни KV стойности

### DIFF
--- a/admin.js
+++ b/admin.js
@@ -330,6 +330,7 @@ document.addEventListener('DOMContentLoaded', () => {
         `Синхронизирано. Обновени: ${result.updated.length}, изтрити: ${result.deleted.length}`,
         'success'
       );
+      await fetch(`${WORKER_BASE_URL}/admin/cleanup`, { method: 'POST' });
       await loadKeys();
     } catch (err) {
       showMessage('Грешка: ' + err.message);


### PR DESCRIPTION
## Summary
- добавена `cleanupKv` функция за изтриване на празни или липсващи KV записи
- нов `/admin/cleanup` endpoint в worker-а
- админ интерфейсът извиква cleanup след sync и обновява списъка с ключове

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4935425548326a6f93db6c46891f6