### PR TITLE
Reset analysis schema cache after KV sync

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -17,6 +17,7 @@
       <div class="admin-actions">
         <button id="sync-btn" class="cta-button">Синхронизирай директно</button>
         <button id="upload-btn" class="cta-button">Качи всички KV</button>
+        <button id="reload-worker" class="cta-button">Презареди worker</button>
       </div>
       <h2>Настройки на бота</h2>
       <div class="kv-editor">

--- a/admin.js
+++ b/admin.js
@@ -17,6 +17,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const newModelInput = document.getElementById('new-model');
   const addModelBtn = document.getElementById('add-model');
   const modelListEl = document.getElementById('model-list');
+  const reloadWorkerBtn = document.getElementById('reload-worker');
 
   const DEFAULT_MODEL_OPTIONS = {
     gemini: ['gemini-1.5-pro', 'gemini-1.5-flash'],
@@ -339,6 +340,7 @@ document.addEventListener('DOMContentLoaded', () => {
       );
       await fetch(`${WORKER_BASE_URL}/admin/cleanup`, { method: 'POST' });
       await loadKeys();
+      showMessage('Worker и промптът са актуализирани', 'success');
     } catch (err) {
       showMessage('Грешка: ' + err.message);
     } finally {
@@ -366,6 +368,21 @@ document.addEventListener('DOMContentLoaded', () => {
     } finally {
       hideLoading();
       uploadBtn.disabled = false;
+    }
+  });
+
+  reloadWorkerBtn.addEventListener('click', async () => {
+    reloadWorkerBtn.disabled = true;
+    showLoading();
+    try {
+      const res = await fetch(`${WORKER_BASE_URL}/admin/cleanup`, { method: 'POST' });
+      if (!res.ok) throw new Error(await res.text());
+      showMessage('Worker презареден', 'success');
+    } catch (err) {
+      showMessage('Грешка: ' + err.message);
+    } finally {
+      hideLoading();
+      reloadWorkerBtn.disabled = false;
     }
   });
 

--- a/worker.js
+++ b/worker.js
@@ -414,6 +414,7 @@ async function handleAdmin(request, env) {
     }
     if (url.pathname === '/admin/cleanup' && request.method === 'POST') {
         const result = await cleanupKv(env);
+        resetAnalysisJsonSchemaCache();
         return new Response(JSON.stringify(result), {
             headers: corsHeaders(request, env, { 'Content-Type': 'application/json' })
         });
@@ -522,6 +523,7 @@ async function adminSync(env, request) {
             namespaceId: env.CF_KV_NAMESPACE_ID,
             apiToken: env.CF_API_TOKEN
         });
+        resetAnalysisJsonSchemaCache();
         return new Response(JSON.stringify(result), {
             headers: corsHeaders(request, env, { 'Content-Type': 'application/json' })
         });


### PR DESCRIPTION
## Summary
- Reset analysis schema cache after KV sync and manual cleanup so new JSON schemas load on next analysis
- Notify admin after successful RAG sync and add manual "reload worker" control

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b496a023608326897fd93056aa1c55