### PR TITLE
Конфигурация на RAG KV namespace

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -2,7 +2,7 @@ name = "iris-worker"
 main = "worker.js"
 compatibility_date = "2024-01-01"
 
-kv_namespaces = [{ binding = "iris_rag_kv", id = "..." }]
+kv_namespaces = [{ binding = "RAG", id = "a7db6bdf8bc94d6d88ec860f4c316fbd" }]
 
 [vars]
 gemini_api_key = ""


### PR DESCRIPTION
## Резюме
- зададено е реалното ID на RAG KV namespace в `wrangler.toml` с binding `RAG`

## Тестване
- `npm test`
- `npx wrangler publish` *(неуспешно: Unknown argument: publish)*
- `npx wrangler deploy` *(неуспешно: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b49d4960fc8326a45f03df46a85f60