### PR TITLE
Use iris_rag_kv for RAG storage

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -304,8 +304,8 @@ export function resolveAlias(key, group = {}) {
 }
 
 async function getGrouped(env) {
-    const { RAG } = env;
-    if (!RAG) throw new Error("KV Namespace 'RAG' не е свързан с този Worker.");
+    const RAG = env.iris_rag_kv;
+    if (!RAG) throw new Error("KV Namespace 'iris_rag_kv' не е свързан с този Worker.");
 
     const cache = /** @type {any} */ (caches).default;
     const ttl = parseInt(env.RAG_CACHE_TTL, 10) || 300;

--- a/worker.test.js
+++ b/worker.test.js
@@ -607,7 +607,7 @@ test('fetchRagData използва кеша при второ извикван�
   };
   let kvCalls = 0;
   const env = {
-    RAG: {
+    iris_rag_kv: {
       get: async () => { kvCalls++; return { findings: { a: { v: 1 } } }; }
     },
     RAG_CACHE_TTL: '60'
@@ -623,7 +623,7 @@ test('fetchRagData използва кеша при второ извикван�
 test('fetchRagData извлича само данни за DISPOSITION_ACIDITY', async () => {
   globalThis.caches = { default: { match: async () => null, put: async () => {} } };
   const env = {
-    RAG: {
+    iris_rag_kv: {
       get: async () => ({ findings: { DISPOSITION_ACIDITY: { key: 'DISPOSITION_ACIDITY' }, OTHER: { key: 'OTHER' } } })
     }
   };
@@ -635,7 +635,7 @@ test('fetchRagData извлича само данни за DISPOSITION_ACIDITY',
 test('fetchRagData извлича новите ключове', async () => {
   globalThis.caches = { default: { match: async () => null, put: async () => {} } };
   const env = {
-    RAG: {
+    iris_rag_kv: {
       get: async () => ({
         advice: { RECOMMENDATION_HYDRATION: { water: true } },
         findings: { DISPOSITION_LYMPHATIC: { lymph: true } }
@@ -655,7 +655,7 @@ test('fetchRagData извлича новите ключове', async () => {
 
 test('fetchRagData логва едно предупреждение за липсващи ключове', async () => {
   globalThis.caches = { default: { match: async () => null, put: async () => {} } };
-  const env = { RAG: { get: async () => ({ findings: {} }) } };
+  const env = { iris_rag_kv: { get: async () => ({ findings: {} }) } };
   const warnings = [];
   const originalWarn = console.warn;
   console.warn = msg => warnings.push(msg);
@@ -675,21 +675,19 @@ test('handleAnalysisRequest преобразува алиасите към ка�
   form.append('right-eye', new File([buf], 'r.jpg', { type: 'image/jpeg' }));
   const req = new Request('https://example.com/analyze', { method: 'POST', body: form });
 
-  const env = {
-    AI_PROVIDER: 'openai',
-    openai_api_key: 'k',
-    iris_rag_kv: {
-      get: async key => {
-        if (key === 'AI_MODEL') return 'gpt-4o';
-        if (key === 'ROLE_PROMPT') return { prompt: '' };
-        return { ok: true };
-      },
-      put: async () => {}
-    },
-    RAG: {
-      get: async () => ({ findings: { SIGN_IRIS_RADII_SOLARIS: { ok: true, aliases: ['SIGN_RADIAL_FURROW'] } } })
-    }
-  };
+   const env = {
+     AI_PROVIDER: 'openai',
+     openai_api_key: 'k',
+     iris_rag_kv: {
+       get: async key => {
+         if (key === 'AI_MODEL') return 'gpt-4o';
+         if (key === 'ROLE_PROMPT') return { prompt: '' };
+         if (key === 'grouped') return { findings: { SIGN_IRIS_RADII_SOLARIS: { ok: true, aliases: ['SIGN_RADIAL_FURROW'] } } };
+         return { ok: true };
+       },
+       put: async () => {}
+     }
+   };
   globalThis.caches = { default: { match: async () => null, put: async () => {} } };
 
   const responses = [
@@ -784,17 +782,20 @@ test('handleAnalysisRequest пропуска извличането на пуб�
   form.append('right-eye', new File([buf], 'r.jpg', { type: 'image/jpeg' }));
   const req = new Request('https://example.com/analyze', { method: 'POST', body: form });
 
-  const env = {
-    AI_PROVIDER: 'openai',
-    openai_api_key: 'k',
-    iris_rag_kv: {
-      get: async key => (key === 'DISPOSITION_NERVOUS' ? {} : null),
-      put: async () => {}
-    },
-    RAG: {
-      get: async () => ({ findings: { DISPOSITION_NERVOUS: { aliases: ['нервна система'] } } })
-    }
-  };
+    const env = {
+      AI_PROVIDER: 'openai',
+      openai_api_key: 'k',
+      iris_rag_kv: {
+        get: async key => {
+          if (key === 'AI_MODEL') return 'gpt-4o';
+          if (key === 'ROLE_PROMPT') return { prompt: '' };
+          if (key === 'DISPOSITION_NERVOUS') return {};
+          if (key === 'grouped') return { findings: { DISPOSITION_NERVOUS: { aliases: ['нервна система'] } } };
+          return null;
+        },
+        put: async () => {}
+      }
+    };
   globalThis.caches = { default: { match: async () => null, put: async () => {} } };
 
   const responses = [


### PR DESCRIPTION
## Summary
- switch worker to use `env.iris_rag_kv` instead of destructured `RAG`
- update RAG-related tests to align with new namespace

## Testing
- `npm test worker.test.js -t "fetchRagData"`

------
https://chatgpt.com/codex/tasks/task_e_68b4aefc76a08326a29eed057aeaacc2