### PR TITLE
chore: configure kv binding id

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -2,7 +2,7 @@ name = "iris-worker"
 main = "worker.js"
 compatibility_date = "2024-01-01"
 
-kv_namespaces = [{ binding = "iris_rag_kv", id = "..." }]
+kv_namespaces = [{ binding = "iris_rag_kv", id = "a7db6bdf8bc94d6d88ec860f4c316fbd" }]
 
 [vars]
 gemini_api_key = ""


### PR DESCRIPTION
## Summary
- set KV binding id for iris_rag_kv in wrangler config

## Testing
- `npm test`
- `npx -y wrangler@3 dev --port=8787`
- `curl -s -o /tmp/analyze.out -w "%{http_code}" -X POST http://localhost:8787/analyze`

------
https://chatgpt.com/codex/tasks/task_e_68b4fbab205c8326b18ddaa06571bd1d