### PR TITLE
Add USER_PROFILE KV integration for analysis

### DIFF
--- a/script.js
+++ b/script.js
@@ -237,6 +237,18 @@ document.addEventListener('DOMContentLoaded', function() {
         if (leftFile) formData.set('left-eye-upload', leftFile, leftFile.name);
         if (rightFile) formData.set('right-eye-upload', rightFile, rightFile.name);
 
+        // Извличаме профилни данни и ги записваме като отделен ключ
+        const profile = {
+            age: formData.get('age'),
+            digestion: (() => {
+                const arr = formData.getAll('digestion');
+                const other = formData.get('digestion-other');
+                if (other) arr.push(other);
+                return arr;
+            })()
+        };
+        formData.set('USER_PROFILE', JSON.stringify(profile));
+
         const storedForm = {};
         for (const [key, value] of formData.entries()) {
             if (value instanceof File) {


### PR DESCRIPTION
## Summary
- store minimal user profile in form submission and send as USER_PROFILE
- worker saves USER_PROFILE to KV and reloads for final synthesis
- cover flow with new unit test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b505638ad88326b9a3a58496822ce1