### PR TITLE
Increase image size limit to 20MB

### DIFF
--- a/script.js
+++ b/script.js
@@ -85,10 +85,10 @@ document.addEventListener('DOMContentLoaded', function() {
                 return;
             }
 
-            // Проверка за размер на файла (до 5MB)
-            const maxSize = 5 * 1024 * 1024;
+            // Проверка за размер на файла (до 20MB)
+            const maxSize = 20 * 1024 * 1024;
             if (file.size > maxSize) {
-                showError('Файлът трябва да е до 5MB.');
+                showError('Файлът трябва да е до 20MB.');
                 input.value = '';
                 if (fileNameEl) fileNameEl.textContent = '';
                 return;

--- a/worker.js
+++ b/worker.js
@@ -1062,7 +1062,7 @@ function formatUserData(data) {
 }
 
 // Проверява дали изображението не надвишава максималния допустим размер.
-async function validateImageSize(file, env = {}, maxBytes = 10 * 1024 * 1024) {
+async function validateImageSize(file, env = {}, maxBytes = 20 * 1024 * 1024) {
     const log = (...args) => debugLog(env, ...args);
     log(`Валидиране на файл: ${file.name}, размер: ${file.size} байта.`);
     if (file.size > maxBytes) {
@@ -1076,8 +1076,13 @@ async function fileToBase64(blob, env = {}) {
     const arrayBuffer = await blob.arrayBuffer();
     const bytes = new Uint8Array(arrayBuffer);
 
-    let binary = "";
-    bytes.forEach(b => (binary += String.fromCharCode(b)));
+    const chunkSize = 0x8000;
+    const chunks = [];
+    for (let i = 0; i < bytes.length; i += chunkSize) {
+        const chunk = bytes.subarray(i, i + chunkSize);
+        chunks.push(String.fromCharCode(...chunk));
+    }
+    const binary = chunks.join('');
 
     // За текст с Unicode може да се използва:
     // btoa(unescape(encodeURIComponent(binary)))

--- a/worker.test.js
+++ b/worker.test.js
@@ -21,7 +21,7 @@ test('kv-data съдържа очакваните RAG ключове', () => {
 });
 
 test('validateImageSize връща грешка при твърде голям файл', async () => {
-  const bigBuffer = Buffer.alloc(11 * 1024 * 1024, 0); // 11MB
+  const bigBuffer = Buffer.alloc(21 * 1024 * 1024, 0); // 21MB
   const bigFile = new File([bigBuffer], 'big.jpg', { type: 'image/jpeg' });
   await assert.rejects(() => validateImageSize(bigFile));
 });


### PR DESCRIPTION
## Summary
- allow uploads up to 20MB in the client and worker
- optimize base64 encoding to process data in chunks
- update tests for new limit

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b76919778083269f43cbca534120ac