### PR TITLE
Добавена проверка за задължителните RAG ключове

### DIFF
--- a/worker.test.js
+++ b/worker.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import worker, { validateImageSize, fileToBase64, uploadImageAndGetUrl, corsHeaders, getAIProvider, getAIModel, callOpenAIAPI, callGeminiAPI, fetchRagData, fetchExternalInfo, generateSummary, RAG_KEYS_JSON_SCHEMA, getAnalysisJsonSchema, resetAnalysisJsonSchemaCache, resolveAlias } from './worker.js';
+import worker, { validateImageSize, fileToBase64, uploadImageAndGetUrl, corsHeaders, getAIProvider, getAIModel, callOpenAIAPI, callGeminiAPI, fetchRagData, fetchExternalInfo, generateSummary, RAG_KEYS_JSON_SCHEMA, getAnalysisJsonSchema, resetAnalysisJsonSchemaCache, resolveAlias, verifyRagKeys } from './worker.js';
 import { KV_DATA } from './kv-data.js';
 import { validateRagKeys } from './validate-rag-keys.js';
 
@@ -18,6 +18,11 @@ test('ROLE_PROMPT съдържа ключ missing_data', () => {
 
 test('kv-data съдържа очакваните RAG ключове', () => {
   validateRagKeys();
+});
+
+test('verifyRagKeys хвърля грешка при липсващи RAG ключове', async () => {
+  const env = { iris_rag_kv: { get: async () => null } };
+  await assert.rejects(() => verifyRagKeys(env), /Липсващи RAG ключове/);
 });
 
 test('validateImageSize връща грешка при твърде голям файл', async () => {


### PR DESCRIPTION
## Резюме
- добавена е функция `verifyRagKeys` за проверка на `grouped:findings`, `grouped:links`, `grouped:advice`
- `getGrouped` използва новата функция и връща грешка при липсващи ключове
- добавен е тест за очакваното поведение при празно KV

## Тестване
- `npm test worker.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b7694c93a0832693efbf0a938c7e7d