### PR TITLE
Make analysis schema optional and render report dynamically

### DIFF
--- a/report.html
+++ b/report.html
@@ -44,8 +44,7 @@ document.addEventListener('DOMContentLoaded', function () {
     // Показване на съобщение за зареждане, докато се обработват данните
     reportCard.innerHTML = `<div class="loading-box"><i class="fas fa-spinner fa-spin"></i> Генериране на доклада...</div>`;
 
-    // Дефинираме конфигурация за всяка секция от доклада
-    // Това прави кода по-лесен за поддръжка и превод
+    // Конфигурация по подразбиране за познати ключове
     const reportSectionsConfig = {
         "summary": { title: "Общо Резюме", icon: "fa-heart-pulse" },
         "constitution": { title: "Конституционални Характеристики", icon: "fa-shield-halved" },
@@ -68,10 +67,10 @@ document.addEventListener('DOMContentLoaded', function () {
             reportCard.innerHTML = '';
             let disclaimer = '';
 
-            // Обхождаме конфигурацията, за да подредим секциите в правилния ред
-            Object.keys(reportSectionsConfig).forEach(key => {
+            // Обхождаме всички ключове, върнати от AI
+            Object.keys(data).forEach(key => {
                 const value = data[key];
-                if (!value) return; // Ако AI не е върнал такъв ключ, пропускаме го
+                if (!value) return;
 
                 // Проверяваме дали стойността съдържа дисклеймъра и я отделяме
                 if (typeof value === 'string' && value.includes("Важно:")) {
@@ -79,20 +78,20 @@ document.addEventListener('DOMContentLoaded', function () {
                     return; // Не го рендираме като нормална секция
                 }
 
-                const config = reportSectionsConfig[key];
-                const wrapper = config.collapsible ? document.createElement('details') : document.createElement('div');
+                const cfg = reportSectionsConfig[key] || { title: key.replace(/_/g, ' '), icon: 'fa-circle-info' };
+                const wrapper = cfg.collapsible ? document.createElement('details') : document.createElement('div');
                 wrapper.className = 'report-section';
 
                 let contentContainer = wrapper;
-                if (config.collapsible) {
+                if (cfg.collapsible) {
                     const summary = document.createElement('summary');
-                    summary.innerHTML = `<i class="fas ${config.icon}"></i> ${config.title}`;
+                    summary.innerHTML = `<i class="fas ${cfg.icon}"></i> ${DOMPurify.sanitize(cfg.title)}`;
                     wrapper.appendChild(summary);
                     contentContainer = document.createElement('div');
                     wrapper.appendChild(contentContainer);
                 } else {
                     const titleEl = document.createElement('h3');
-                    titleEl.innerHTML = `<i class="fas ${config.icon}"></i> ${config.title}`;
+                    titleEl.innerHTML = `<i class="fas ${cfg.icon}"></i> ${DOMPurify.sanitize(cfg.title)}`;
                     wrapper.appendChild(titleEl);
                 }
 

--- a/worker.js
+++ b/worker.js
@@ -171,7 +171,7 @@ export async function getAIModel(env = {}) {
     return provider === 'openai' ? 'gpt-4o' : 'gemini-1.5-pro';
 }
 
-// Гарантира присъствието на задължителните полета в схемата
+// Гарантира присъствието на ключови полета, но не ги маркира като задължителни
 function ensureAnalysisSchema(schema = {}) {
     if (!schema.properties) schema.properties = {};
     for (const key of ['summary', 'recommendations', 'holistic_analysis']) {
@@ -179,12 +179,7 @@ function ensureAnalysisSchema(schema = {}) {
             schema.properties[key] = { type: 'string' };
         }
     }
-    if (!Array.isArray(schema.required)) schema.required = [];
-    for (const key of ['summary', 'recommendations', 'holistic_analysis']) {
-        if (!schema.required.includes(key)) {
-            schema.required.push(key);
-        }
-    }
+    // Оставяме дефиницията на "required" на подадената схема
     return schema;
 }
 
@@ -640,7 +635,6 @@ const ANALYSIS_JSON_SCHEMA = {
             recommendations: { type: 'string' },
             holistic_analysis: { type: 'string' }
         },
-        required: ['summary', 'recommendations', 'holistic_analysis'],
         additionalProperties: true
     }
 };

--- a/worker.test.js
+++ b/worker.test.js
@@ -217,7 +217,7 @@ test('getAnalysisJsonSchema кешира резултата от KV', { concurre
   const second = await getAnalysisJsonSchema(env);
   assert.equal(calls, 1);
   assert.deepEqual(first, second);
-  assert.deepEqual(first.schema.required.sort(), ['holistic_analysis', 'recommendations', 'summary']);
+  assert.deepEqual(first.schema.required.sort(), ['summary']);
   resetAnalysisJsonSchemaCache();
 });
 
@@ -231,7 +231,7 @@ test('getAnalysisJsonSchema използва структура от ENV', { con
   };
   const result = await getAnalysisJsonSchema(env);
   assert.equal(result.name, 'custom');
-  assert.deepEqual(result.schema.required.sort(), ['holistic_analysis', 'recommendations', 'summary']);
+  assert.deepEqual(result.schema.required.sort(), ['summary']);
   resetAnalysisJsonSchemaCache();
 });
 
@@ -824,7 +824,7 @@ test('generateSummary приема custom json_schema', { concurrency: 1 }, asyn
   globalThis.fetch = originalFetch;
   const sent = bodies[0].response_format.json_schema;
   assert.equal(sent.name, 'custom');
-  assert.deepEqual(sent.schema.required.sort(), ['extra', 'holistic_analysis', 'recommendations', 'summary']);
+  assert.deepEqual(sent.schema.required.sort(), ['extra']);
   resetAnalysisJsonSchemaCache();
 });
 


### PR DESCRIPTION
## Summary
- Make analysis JSON schema optional by removing automatic required fields
- Render report sections dynamically based on keys returned by the analysis
- Adjust unit tests for new schema flexibility

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba38a4e1248326a6c2e89b137232d6