### PR TITLE
Преименуване на Gemini променлива в wrangler.toml

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -5,7 +5,7 @@ compatibility_date = "2024-01-01"
 kv_namespaces = [{ binding = "iris_rag_kv", id = "a7db6bdf8bc94d6d88ec860f4c316fbd" }]
 
 [vars]
-gemini_api_key = ""
+GEMINI_API_KEY = ""
 openai_api_key = ""
 allowed_origin = "*"
 DEBUG = "false" # Set to "true" for detailed logging


### PR DESCRIPTION
## Summary
- Rename worker variable from `gemini_api_key` to `GEMINI_API_KEY`.
- Confirm worker uses `env.GEMINI_API_KEY` for Gemini calls.

## Testing
- `npm test`
- `wrangler deploy` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68bf7268b68083268d461f3ea1a8d234