### PR TITLE
feat: helper за формат на текст и икони

### DIFF
--- a/report.html
+++ b/report.html
@@ -120,9 +120,20 @@
             "default": { icon: "fa-circle-info", color: "#6b7280" }
         };
 
+        function formatTextContent(text) {
+            const lines = DOMPurify.sanitize(text).split('\n').filter(l => l.trim() !== '');
+            if (lines.length > 1) {
+                const items = lines
+                    .map(line => `<li><i class="fas fa-check-circle"></i>${line.trim()}</li>`)
+                    .join('');
+                return `<ul>${items}</ul>`;
+            }
+            return `<p>${lines[0] || ''}</p>`;
+        }
+
         function renderReport(data) {
             const container = document.getElementById('report-container');
-            container.innerHTML = ''; 
+            container.innerHTML = '';
 
             const hero = document.createElement('div');
             hero.className = 'report-hero';
@@ -149,7 +160,7 @@
                     } else if (key === 'Анализ на елиминативните канали') {
                         section = createChannelsSection(key, content);
                     } else {
-                        section = createCollapsibleSection(key, `<p>${DOMPurify.sanitize(content)}</p>`);
+                        section = createCollapsibleSection(key, formatTextContent(content));
                     }
                     container.appendChild(section);
                 }
@@ -206,7 +217,7 @@
         
         function createChannelsSection(title, content) {
             const channels = ['черва', 'бъбреци', 'лимфа', 'кожа', 'бели дробове'];
-            let contentHTML = `<p>${DOMPurify.sanitize(content)}</p><br><h4>Визуална оценка на натовареността:</h4>`;
+            let contentHTML = `${formatTextContent(content)}<br><h4>Визуална оценка на натовареността:</h4>`;
             channels.forEach(channel => {
                 let level = 'low';
                 let width = '33%';

--- a/style.css
+++ b/style.css
@@ -94,7 +94,7 @@ body { font-family: 'Poppins', sans-serif; background-color: var(--bg-color); co
 .report-section p, .report-section ul { font-size: 1rem; line-height: 1.7; color: #555; }
 .report-section ul { list-style: none; padding-left: 0; }
 .report-section ul li { display: flex; align-items: flex-start; margin-bottom: 0.8rem; }
-.report-section ul li i { color: var(--secondary-color); margin-right: 1rem; margin-top: 5px; }
+.report-section ul li i { color: var(--primary-color); margin-right: 0.75rem; font-size: 1rem; margin-top: 0.25rem; }
 .report-disclaimer { display: flex; align-items: flex-start; gap: 1rem; background-color: #f8f9fa; padding: 1.5rem; border-radius: 12px; margin-top: 2rem; border-left: 4px solid var(--primary-color); }
 .report-disclaimer i { color: var(--primary-color); font-size: 1.5rem; margin-top: 3px; }
 .report-disclaimer p { font-size: 0.9rem; margin: 0; }


### PR DESCRIPTION
## Summary
- добавен `formatTextContent` за автоматично генериране на списъци или абзаци с икони
- използване на `formatTextContent` в `renderReport` и `createChannelsSection`
- стил за иконите в елементите на списъци

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf9814b43c8326ac3419d080bbfd6f