### PR TITLE
Allow newlines in report paragraphs

### DIFF
--- a/style.css
+++ b/style.css
@@ -92,6 +92,7 @@ body { font-family: 'Poppins', sans-serif; background-color: var(--bg-color); co
 .report-section h3 { display: flex; align-items: center; font-size: 1.5rem; margin-bottom: 1rem; }
 .report-section h3 i { color: var(--primary-color); font-size: 1.3rem; margin-right: 1rem; width: 30px; text-align: center; }
 .report-section p, .report-section ul { font-size: 1rem; line-height: 1.7; color: #555; }
+.report-section p { white-space: pre-line; margin: 0 0 1rem; }
 .report-section ul { list-style: none; padding-left: 0; }
 .report-section ul li { display: flex; align-items: flex-start; margin-bottom: 0.8rem; }
 .report-section ul li i { color: var(--primary-color); margin-right: 0.75rem; font-size: 1rem; margin-top: 0.25rem; }


### PR DESCRIPTION
## Summary
- allow pre-line whitespace inside `.report-section p`
- normalize paragraph spacing in report sections

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf9a0ce0b48326b8f14f6b337d3abc