### PR TITLE
Добавена конфигурация на AI модела през KV

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,28 @@ npm install
 3. Деплой чрез `wrangler publish`.
 4. Хоствайте статичните файлове (например GitHub Pages на `https://radilovk.github.io`).
 
+### Пример: задаване на AI модел и промпт
+
+Админ панелът записва стойности в `iris_config_kv`:
+
+```js
+// смяна на модела
+fetch('https://<worker-url>/admin/set', {
+  method: 'PUT',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({ key: 'AI_MODEL', value: 'gemini-1.5-flash-latest' })
+});
+
+// задаване на ROLE_PROMPT
+fetch('https://<worker-url>/admin/put', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({ key: 'ROLE_PROMPT', value: JSON.stringify({ prompt: 'Ти си холистичен консултант...' }) })
+});
+```
+
+Подобно се задава и `AI_PROVIDER`.
+
 ## Примерна заявка
 
 ```bash

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -2,7 +2,10 @@ name = "iris-worker"
 main = "worker.js"
 compatibility_date = "2024-01-01"
 
-kv_namespaces = [{ binding = "iris_rag_kv", id = "a7db6bdf8bc94d6d88ec860f4c316fbd" }]
+kv_namespaces = [
+  { binding = "iris_rag_kv", id = "a7db6bdf8bc94d6d88ec860f4c316fbd" },
+  { binding = "iris_config_kv", id = "" } # задайте ID на вашия KV
+]
 
 [vars]
 GEMINI_API_KEY = ""


### PR DESCRIPTION
## Резюме
- добавено четене на `AI_PROVIDER`, `AI_MODEL` и `ROLE_PROMPT` от `iris_config_kv`
- параметризирани промптовете и модела с fallback стойности
- описан пример за задаване на ключове през админ панела и нов KV namespace

## Тестване
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c211b9ee108326815f1f525f21c79a