### PR TITLE
Подобрени карти и рендериране на препоръки

### DIFF
--- a/analysis.html
+++ b/analysis.html
@@ -8,9 +8,14 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css">
-    <link rel="stylesheet" href="style.css"> 
+    <link rel="stylesheet" href="style.css">
+    <style>
+        :root {
+            --card-bg: rgba(255, 255, 255, 0.9);
+        }
+    </style>
 </head>
-<body>
+<body class="gradient-background">
 
     <div class="container">
 

--- a/index.html
+++ b/index.html
@@ -244,8 +244,8 @@
         }
 
         .solution-card {
-            background: var(--card-bg);
-            border: 1px solid var(--border-color);
+            background: linear-gradient(135deg, rgba(58, 123, 213, 0.15), rgba(58, 172, 237, 0.15));
+            border: 1px solid rgba(58, 123, 213, 0.3);
             border-radius: 20px;
             padding: 30px;
             backdrop-filter: blur(12px);

--- a/report.html
+++ b/report.html
@@ -204,8 +204,16 @@
 
         // Функция за форматиране на Markdown към HTML
         function formatTextContent(text) {
-            if (!text) return '';
-            let sanitizedText = DOMPurify.sanitize(text, { USE_PROFILES: { html: false } });
+            if (text == null) return '';
+            if (Array.isArray(text)) {
+                return `<ul>${text.map(item => `<li>${formatTextContent(item)}</li>`).join('')}</ul>`;
+            }
+            if (typeof text === 'object') {
+                const main = formatTextContent(text.text || Object.values(text).join(' '));
+                const source = text.source ? `<p><em>Източник: ${DOMPurify.sanitize(text.source)}</em></p>` : '';
+                return main + source;
+            }
+            let sanitizedText = DOMPurify.sanitize(String(text), { USE_PROFILES: { html: false } });
             let html = sanitizedText.replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>');
             const blocks = html.split(/\n\s*\n/);
             const processedBlocks = blocks.map(block => {


### PR DESCRIPTION
## Резюме
- Усилен контраст на solution-card секцията в началната страница.
- Анализ страницата използва градиентен фон и полупрозрачни контейнери за по-добра визуална консистентност.
- Поправено визуализиране на "Целенасочени препоръки" в доклада чрез обработка на масиви и обекти.

## Тестване
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4df2897788326b888a54163f25be2